### PR TITLE
Reworked Fortitude and Iron Mountain to use Damage_Resistance

### DIFF
--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -1200,17 +1200,17 @@
 	cost_demon = 1
 	discipline_type = "Demon"
 
+/datum/chi_discipline/iron_mountain/post_gain(mob/living/carbon/human/user)
+	user.physiology.damage_resistance += (5+(5*level))
+
 /datum/chi_discipline/iron_mountain/activate(mob/living/target, mob/living/carbon/human/caster)
 	..()
-	var/mod = level_casting
-	var/bonus = 15 * mod
-	caster.physiology.armor.melee += bonus
-	caster.physiology.armor.bullet += bonus
+	var/bonus = (5+(5*level))
+	caster.physiology.damage_resistance = min(60, (caster.physiology.damage_resistance+bonus) )
 	spawn(delay+caster.discipline_time_plus)
 		if(caster)
 			caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/ironmountain_deactivate.ogg', 50, FALSE)
-			caster.physiology.armor.melee -= bonus
-			caster.physiology.armor.bullet -= bonus
+		caster.physiology.damage_resistance = max(0, (caster.physiology.damage_resistance-bonus) )
 
 /datum/chi_discipline/kiai
 	name = "Kiai"

--- a/code/modules/wod13/datums/powers/discipline/fortitude.dm
+++ b/code/modules/wod13/datums/powers/discipline/fortitude.dm
@@ -10,9 +10,13 @@
 
 	activate_sound = 'code/modules/wod13/sounds/fortitude_activate.ogg'
 	deactivate_sound = 'code/modules/wod13/sounds/fortitude_deactivate.ogg'
-	
-	power_group = DISCIPLINE_POWER_GROUP_COMBAT
 
+	power_group = DISCIPLINE_POWER_GROUP_COMBAT
+	var/fortitude_DR
+
+/datum/discipline/fortitude/post_gain()
+	. = ..()
+	owner.physiology.damage_resistance += (5+(5*level))
 
 //FORTITUDE 1
 /datum/discipline_power/fortitude/one
@@ -32,18 +36,15 @@
 		/datum/discipline_power/fortitude/four,
 		/datum/discipline_power/fortitude/five
 	)
+	fortitude_DR = 10
 
 /datum/discipline_power/fortitude/one/activate()
 	. = ..()
-	owner.physiology.armor.melee += 15
-	owner.physiology.armor.bullet += 15
-	owner.physiology.armor.fire += 10
+	owner.physiology.damage_resistance = min(60, (owner.physiology.damage_resistance+fortitude_DR) )
 
 /datum/discipline_power/fortitude/one/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 15
-	owner.physiology.armor.bullet -= 15
-	owner.physiology.armor.fire -= 10
+	owner.physiology.damage_resistance = max(0, (owner.physiology.damage_resistance-fortitude_DR) )
 
 //FORTITUDE 2
 /datum/discipline_power/fortitude/two
@@ -63,18 +64,15 @@
 		/datum/discipline_power/fortitude/four,
 		/datum/discipline_power/fortitude/five
 	)
+	fortitude_DR = 15
 
 /datum/discipline_power/fortitude/two/activate()
 	. = ..()
-	owner.physiology.armor.melee += 30
-	owner.physiology.armor.bullet += 30
-	owner.physiology.armor.fire += 20
+	owner.physiology.damage_resistance = min(60, (owner.physiology.damage_resistance+fortitude_DR) )
 
 /datum/discipline_power/fortitude/two/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 30
-	owner.physiology.armor.bullet -= 30
-	owner.physiology.armor.fire -= 20
+	owner.physiology.damage_resistance = max(0, (owner.physiology.damage_resistance-fortitude_DR) )
 
 //FORTITUDE 3
 /datum/discipline_power/fortitude/three
@@ -94,18 +92,15 @@
 		/datum/discipline_power/fortitude/four,
 		/datum/discipline_power/fortitude/five
 	)
+	fortitude_DR = 20
 
 /datum/discipline_power/fortitude/three/activate()
 	. = ..()
-	owner.physiology.armor.melee += 45
-	owner.physiology.armor.bullet += 45
-	owner.physiology.armor.fire += 30
+	owner.physiology.damage_resistance = min(60, (owner.physiology.damage_resistance+fortitude_DR) )
 
 /datum/discipline_power/fortitude/three/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 45
-	owner.physiology.armor.bullet -= 45
-	owner.physiology.armor.fire -= 30
+	owner.physiology.damage_resistance = max(0, (owner.physiology.damage_resistance-fortitude_DR) )
 
 //FORTITUDE 4
 /datum/discipline_power/fortitude/four
@@ -125,18 +120,16 @@
 		/datum/discipline_power/fortitude/three,
 		/datum/discipline_power/fortitude/five
 	)
+	fortitude_DR = 25
 
 /datum/discipline_power/fortitude/four/activate()
 	. = ..()
-	owner.physiology.armor.melee += 60
-	owner.physiology.armor.bullet += 60
-	owner.physiology.armor.fire += 40
+	owner.physiology.damage_resistance = min(60, (owner.physiology.damage_resistance+fortitude_DR) )
 
 /datum/discipline_power/fortitude/four/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 60
-	owner.physiology.armor.bullet -= 60
-	owner.physiology.armor.fire -= 40
+	owner.physiology.damage_resistance = max(0, (owner.physiology.damage_resistance-fortitude_DR) )
+
 
 //FORTITUDE 5
 /datum/discipline_power/fortitude/five
@@ -156,15 +149,13 @@
 		/datum/discipline_power/fortitude/three,
 		/datum/discipline_power/fortitude/four
 	)
+	fortitude_DR = 30
 
 /datum/discipline_power/fortitude/five/activate()
 	. = ..()
-	owner.physiology.armor.melee += 75
-	owner.physiology.armor.bullet += 75
-	owner.physiology.armor.fire += 50
+	owner.physiology.damage_resistance = min(60, (owner.physiology.damage_resistance+fortitude_DR) )
 
 /datum/discipline_power/fortitude/five/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 75
-	owner.physiology.armor.bullet -= 75
-	owner.physiology.armor.fire -= 50
+	owner.physiology.damage_resistance = max(0, (owner.physiology.damage_resistance-fortitude_DR) )
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Made Fortitude and Iron Mountain give Damage resistance. Passive as well as more when Activated.

The formula for passive is 5+(5*level) so at rank 5, it's 30% DR.  For Active it's essentially  doubled, so at rank 5 it's 60%

The formulas are also done to clamp your total Damage resistance, so you can't use other DR sources to give you more than 60%

Damage Resistance for those that do not know essentially is a percentage modifeir that reduces damage by the percentage. so 60% DR allows you to only get 40% damage (after armor and other mods are taken accounted for).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fortitude and Iron Mountain feel like actual defensive powers that can make you a tank. It also helps that since the Combat discs are not basically seperated so can't work together. That gives incentive to make each one singularly more stronger 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Passive Fort & Iron mountain (not activated):
![image](https://github.com/user-attachments/assets/081273d0-f847-4388-a54e-61a5939cda4c)

Rank 1 with Max Pasive DR:
![image](https://github.com/user-attachments/assets/6fe6a180-c093-4967-b4f1-3e6586bd33df)


Rank 2:
![image](https://github.com/user-attachments/assets/23e63ffd-1237-4420-bc46-cf0346c55b99)

Rank 3:
![image](https://github.com/user-attachments/assets/1befd721-fee1-41ae-a80e-3c6e1de7c8a4)

Rank 4:
![image](https://github.com/user-attachments/assets/becda567-62f0-4980-9bfb-71f11f98d9ac)

Rank 5:
![image](https://github.com/user-attachments/assets/c496d65a-cc95-4c30-80e5-1aa9299594b7)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Changed Fortitude and Iron Mountain to use damage_resistance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
