### PR TITLE
Fixes invisible bloodbags

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -50,7 +50,7 @@
 		if(0)
 			icon_state = "blood0"
 	inhand_icon_state = icon_state
-	onflooricon_state = icon_state
+	onflooricon_state = onflooricon
 
 /// Handles updating the container when the reagents change.
 /obj/item/reagent_containers/blood/on_reagent_change(datum/reagents/holder, ...)


### PR DESCRIPTION
This PR fixes invisible bloodbags floor sprites


## About The Pull Request

onflooricon_state was being assigned as icon_state instead of onflooricon

## Why It's Good For The Game

bug fix

## Testing Photographs and Procedure

![dreammaker_QETEH37GHX](https://github.com/user-attachments/assets/78620d5c-08a7-45e9-94e2-c658e69405c1)

i just tested it in a testserver with o- and ab positive bloodbags and it works but i didnt get screencaps

## Changelog


:cl:
bugfix: fixes invisible bloodbags
/:cl:

