### PR TITLE
REFACTORED THE SHAPESHIFT DAMAGE PROC FOR RESTORE PROC (You don't turbo die when you shapeshift back anymore)

### DIFF
--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -191,13 +191,13 @@
 	else if(source.convert_damage)
 		stored.revive(full_heal = TRUE, admin_revive = FALSE)
 
-		var/dam_percentage = ((shape.health / shape.maxHealth) * 100) // getting percentage of your current hp compared to max HP in shape form
+		var/dam_percentage = ((shape.health / shape.maxHealth)) // getting percentage of your current hp compared to max HP in shape form
 		var/percent_carbon = (stored.maxHealth * dam_percentage) //this will get the HP remaining left you have in carbon form at base
 		var/gross_damage = (stored.maxHealth - percent_carbon) //This will give you the relative percentage damage you'd take once transforming back
 /* EXAMPLE CALCULATION
-dama_percentage = ( 1 (current HP) / 1000 (max hp) ) * 100 = 0.1
-percent_carbon = 100 * 0.1 = 10
-gross_damage = 100 - 10 = 90
+dama_percentage = ( 1 (current HP) / 100 (max hp) ) = 0.002
+percent_carbon = 100 * 0.002 = 0.2
+gross_damage = 100 - 10 = 99.75
 
 Result: you take at least 90 damage when you trasnform back
 */

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -191,9 +191,17 @@
 	else if(source.convert_damage)
 		stored.revive(full_heal = TRUE, admin_revive = FALSE)
 
-		var/damage_percent = (shape.maxHealth - shape.health)
+		var/dam_percentage = ((shape.health / shape.maxHealth) * 100) // getting percentage of your current hp compared to max HP in shape form
+		var/percent_carbon = (stored.maxHealth * dam_percentage) //this will get the HP remaining left you have in carbon form at base
+		var/gross_damage = (stored.maxHealth - percent_carbon) //This will give you the relative percentage damage you'd take once transforming back
+/* EXAMPLE CALCULATION
+dama_percentage = ( 1 (current HP) / 1000 (max hp) ) * 100 = 0.1
+percent_carbon = 100 * 0.1 = 10
+gross_damage = 100 - 10 = 90
 
-		stored.apply_damage(damage_percent, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND)
+Result: you take at least 90 damage when you trasnform back
+*/
+		stored.apply_damage(gross_damage, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND)
 //	if(source.convert_damage)
 //		stored.blood_volume = shape.blood_volume;
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently for the shapeshifting spell proc for when you restore to your original form. When it take accounts to how much damage that should be transferred to your original form. It's supposed to make it so that when you transform back, you would take a damage relative to the percentage of what HP you lost in your transformed form. Ergo if you lost 90% of your HP, you would lose only 90% when you transform back into a human mob

However it was coded like this
<img width="456" height="31" alt="image" src="https://github.com/user-attachments/assets/dd081086-d213-48ae-aa1b-b2e9507a33fe" />

Which meant you take a STRAIGHT DIFFERENCE of how much damage you took. So if you had a form with like 500 HP and you took 300 damage. That meant when you transformed back. YOU WOULD TAKE 300 DAMAGE HARD

For obvious reasons I fixed this so now it properly works

<img width="577" height="224" alt="image" src="https://github.com/user-attachments/assets/59600d19-bd0c-475e-8d4e-c8d55215fd97" />


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

# NO LONGER SHALL WE DIE WHEN WE TRANSFORM BACK!! WE ARE NOW UNSTOPPABLE BIT BY BIT!!!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://github.com/user-attachments/assets/0e8904e1-e8df-4d2d-84d5-cae8aed732cc

As shown by here, where before you would be in torpor from your wounds. You instead are heavily hurt but still standing

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Changed how the damage proc for the shapeshift restore() proc was handled so people didnt die hard when they came back (unless they died ish during the transformation)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
