### PR TITLE
Fixes Meleemods for Weapons

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -265,6 +265,12 @@
 		), ARMOR_MAX_BLOCK)
 
 	var/damage = attacking_item.force
+	var/meleemod = 1
+	if(istype(user, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		if(H.dna?.species)
+			meleemod = H.dna.species.meleemod
+	damage = damage * meleemod
 
 	var/wounding = attacking_item.wound_bonus
 	if((attacking_item.item_flags & SURGICAL_TOOL) && !user.combat_mode && body_position == LYING_DOWN && (LAZYLEN(surgeries) > 0))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -265,12 +265,14 @@
 		), ARMOR_MAX_BLOCK)
 
 	var/damage = attacking_item.force
+	//TFN EDIT START -- Fixes Meleemods for Weapons
 	var/meleemod = 1
 	if(istype(user, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.dna?.species)
 			meleemod = H.dna.species.meleemod
 	damage = damage * meleemod
+	//TFN EDIT END -- Fixes Meleemods for Weapons
 
 	var/wounding = attacking_item.wound_bonus
 	if((attacking_item.item_flags & SURGICAL_TOOL) && !user.combat_mode && body_position == LYING_DOWN && (LAZYLEN(surgeries) > 0))


### PR DESCRIPTION
## About The Pull Request

This PR fixes a known bug where a heightened meleemod var didn't apply to any melee strikes besides completely unarmed strikes

## Why It's Good For The Game

bugfix

## Testing Photographs and Procedure
<img width="1095" height="726" alt="dreamseeker_2crxVCh5AJ" src="https://github.com/user-attachments/assets/baa9638d-96ee-429d-afcd-1c87f8700e9b" />
135 brute from two strikes of katana w/ potence 5 against szlachta, 180 from two strikes of katana w/ potence 5 against szlachta

## Changelog
:cl:
bugfix: fixed meleemods not being applied to weapons besides completely unarmed
/:cl:

