### PR TITLE
The Gargoyle Unscrewing part 1

### DIFF
--- a/code/modules/vtmb/vampire_clan/gargoyle.dm
+++ b/code/modules/vtmb/vampire_clan/gargoyle.dm
@@ -25,12 +25,3 @@
 	gargoyle.dna.species.wings_icon = "Gargoyle"
 	gargoyle.physiology.brute_mod = 0.8
 	gargoyle.dna.species.GiveSpeciesFlight(gargoyle)
-
-//	if(gargoyle.shoes)
-//		qdel(gargoyle.shoes)
-//	gargoyle.Digitigrade_Leg_Swap(FALSE) //TODO: Remove shoes first
-
-//	gargoyle.remove_overlay(MARKS_LAYER)
-//	var/mutable_appearance/acc_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "gargoyle_legs_n_tails", -MARKS_LAYER)
-//	gargoyle.overlays_standing[MARKS_LAYER] = acc_overlay
-//	gargoyle.apply_overlay(MARKS_LAYER)


### PR DESCRIPTION
## About The Pull Request

Comments out the gargoyle leg and tail markings from their clan file.

## Why It's Good For The Game

The current legs are, let's be honest here, a completely horrible implementation of the idea and look terrible. They don't match the color scheme, are way too big, and clip through every single piece of clothing. You can't wear shoes either and you have to _spend quirk points_ to not get stunned by broken glass or lights on the floor.  And because of the clipping, it removes any possible subtlety of if that strange robed figure was a supernatural or not (aside from the horns) considering you can literally see right through it. Sure you're kinda supposed to ignore it but you shouldn't have to. All in all it was a very poor bit of code and spritework hastily slapped together for an easy bounty claim and then the guy who did it bounced from the server not long after. Hopefully in the future I can properly do what they wanted to in the future but at the moment this will have to do until I can do better.

If the digitigrade legs and tail are still desired, I have an alternate version I could use that looks much better but with a bit of clipping on different body types. For now though I think a reversion will be _good enough_ in the meantime.

## Testing Photographs and Procedure
<img width="171" height="150" alt="image" src="https://github.com/user-attachments/assets/3176162c-b1dd-48b2-a3a2-db3ba21dbfde" />
<img width="176" height="142" alt="image" src="https://github.com/user-attachments/assets/9d34d275-67b4-4404-bea0-1f9188e4d1d0" />
<img width="183" height="180" alt="image" src="https://github.com/user-attachments/assets/04f41470-bd2c-4fda-a3fd-7a0f487fc8ae" />

As you can see, there's no huge ass legs in sight.

</details>

## Changelog

:cl:
image: Reverted the Gargoyle legs to the old version
/:cl:

