### PR TITLE
.45 for $2,100? What a steal!

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -326,6 +326,13 @@
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo44
+	name = "Ammo (.45 ACP)"
+	desc = "Contains a box of .45 ACP ammunition."
+	cost = 400
+	contains = list(/obj/item/ammo_box/vampire/c45acp = 2)
+	crate_name = "ammo crate"
+
+/datum/supply_pack/vampire/ammo44
 	name = "Ammo (.44)"
 	desc = "Contains a box of .44 ammunition."
 	cost = 600

--- a/code/modules/wod13/items/stores/guns.dm
+++ b/code/modules/wod13/items/stores/guns.dm
@@ -7,7 +7,7 @@
 		new /datum/data/mining_equipment("hunting rifle",	/obj/item/gun/ballistic/automatic/vampire/huntrifle, 2000),
 		new /datum/data/mining_equipment("fishing rod",		/obj/item/fishing_rod,	200),
 		new	/datum/data/mining_equipment("5.45 ammo",	/obj/item/ammo_box/vampire/c545,	1000),
-		new	/datum/data/mining_equipment(".45 ACP ammo",	/obj/item/ammo_box/vampire/c45acp,	2100),
+		new	/datum/data/mining_equipment(".45 ACP ammo",	/obj/item/ammo_box/vampire/c45acp,	700),
 		new /datum/data/mining_equipment("9mm ammo",	/obj/item/ammo_box/vampire/c9mm,	600),
 		new /datum/data/mining_equipment(".44 ammo",	/obj/item/ammo_box/vampire/c44,	800),
 		new /datum/data/mining_equipment("5.56 ammo",	/obj/item/ammo_box/vampire/c556,	2000),


### PR DESCRIPTION

## About The Pull Request
Makes buying .45 ACP ammo from gunstores reasonable & adds .45 ACP to cargo. Whoever thought .45ACP should cost 2100 was a dumbass.
## Why It's Good For The Game
Finally, the m1911 is economically viable
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
<img width="415" height="77" alt="m1911 1" src="https://github.com/user-attachments/assets/bb65e88b-5d2b-4a3c-82f1-ae94990e80f6" />
<img width="536" height="45" alt="m1911 2" src="https://github.com/user-attachments/assets/9439eda7-ff08-4185-b155-4589acd434c0" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
add: Adds 45acp to cargo orders for 400
fix: fixed the price for 45acp at gunstores, from 2100 to 700
/:cl:
