### PR TITLE
KJ - Giant form + Flame Katana Nerf

### DIFF
--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -1060,7 +1060,7 @@
 					caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/demonshintai_deactivate.ogg', 50, FALSE)
 		if("Giant")
 			var/mod = level_casting*10
-			var/meleemod = level_casting*0.5
+			var/meleemod = level_casting*0.3
 			caster.remove_overlay(UNICORN_LAYER)
 			var/mutable_appearance/potence_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "giant", -UNICORN_LAYER)
 			caster.overlays_standing[UNICORN_LAYER] = potence_overlay

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -137,6 +137,7 @@
 	name = "burning katana"
 	icon_state = "firetana"
 	pixel_w = -8
+	force = 30
 	damtype = BURN
 	item_flags = DROPDEL
 	is_iron = FALSE


### PR DESCRIPTION
thatfuckingnerfthatihatethatfuckingnerfthatihatethatfuckingnerfthatihate
## About The Pull Request
Nerfs giant form meleemod and flame katana's dmg
## Why It's Good For The Game
225 burn is incredibly unbalanced, get the fuck out of here
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
<img width="262" height="107" alt="kj 1" src="https://github.com/user-attachments/assets/3b0899b4-4bf2-4b9e-9a2c-ae6210ae814e" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: nerfs Giant Form from Demon Chi's meleemod from 2.5>1.5
fix: nerfs Ghost Flame's katana from 45 burn > 30 burn
/:cl:
