### PR TITLE
Flame and Blood Katana adjustment

### DIFF
--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -137,6 +137,7 @@
 	name = "burning katana"
 	icon_state = "firetana"
 	pixel_w = -8
+	force = 30
 	damtype = BURN
 	item_flags = DROPDEL
 	is_iron = FALSE
@@ -151,6 +152,7 @@
 	name = "bloody katana"
 	color = "#bb0000"
 	pixel_w = -8
+	force = 30
 	damtype = CLONE
 	item_flags = DROPDEL
 	is_iron = FALSE


### PR DESCRIPTION

## About The Pull Request
This adjusts the damage output of the two katanas to be at 30 apiece per hit. It will not inherit the katanas base attack damage now.

## Why It's Good For The Game
It fixes the issue of both katanas drawing and inheriting the base damage values of the katana weapon.

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/3a06889b-e8a4-4973-a03a-fca12d1be950





## Changelog
:cl:
Bal: Adjusts values for blood and flame katana to be 30
