### PR TITLE
Ports - Rebalances some sizes on containers (#22)

### DIFF
--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -13,7 +13,7 @@
 	var/list/_contents_limbo // Where objects go to live mid transfer
 	var/list/_user_limbo // The last users before the component started moving
 
-/datum/component/storage/concrete/Initialize()
+/datum/component/storage/concrete/Initialize(datum/component/storage/concrete/master, _screen_max_columns, _screen_max_rows)
 	. = ..()
 	RegisterSignal(parent, COMSIG_ATOM_CONTENTS_DEL, PROC_REF(on_contents_del))
 	RegisterSignal(parent, COMSIG_OBJ_DECONSTRUCT, PROC_REF(on_deconstruct))

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -3,7 +3,7 @@
 // /mob/living/Move() in /modules/mob/living/living.dm - hiding storage boxes on mob movement
 
 /datum/component/storage
-	dupe_mode = COMPONENT_DUPE_UNIQUE
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	var/datum/component/storage/concrete/master		//If not null, all actions act on master and this is just an access point.
 
 	var/list/can_hold								//if this is set, only items, and their children, will fit
@@ -55,9 +55,13 @@
 	var/screen_start_y = 9
 	//End
 
-/datum/component/storage/Initialize(datum/component/storage/concrete/master)
+/datum/component/storage/Initialize(datum/component/storage/concrete/master, _screen_max_columns, _screen_max_rows)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
+	if(_screen_max_columns)
+		screen_max_columns = _screen_max_columns
+	if(_screen_max_rows)
+		screen_max_rows = _screen_max_rows
 	if(master)
 		change_master(master)
 	boxes = new(null, src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -31,6 +31,10 @@
 	resistance_flags = FLAMMABLE
 	drop_sound = 'sound/items/handling/cardboardbox_drop.ogg'
 	pickup_sound =  'sound/items/handling/cardboardbox_pickup.ogg'
+	grid_width = 3 GRID_BOXES
+	grid_height = 3 GRID_BOXES
+	storage_max_columns = 4
+	storage_max_rows = 4
 	var/foldable = /obj/item/stack/sheet/cardboard
 	var/illustration = "writing"
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -18,6 +18,8 @@
 	icon = 'icons/obj/food/containers.dmi'
 	resistance_flags = FLAMMABLE
 	custom_materials = list(/datum/material/cardboard = 2000)
+	storage_max_columns = 5
+	storage_max_rows = 5
 	var/icon_type = "donut"
 	var/spawn_type = null
 	var/fancy_open = FALSE
@@ -79,6 +81,8 @@
 	fancy_open = TRUE
 	appearance_flags = KEEP_TOGETHER
 	custom_premium_price = PAYCHECK_HARD * 1.75
+	storage_max_columns = 6
+	storage_max_rows = 2
 
 /obj/item/storage/fancy/donut_box/ComponentInitialize()
 	. = ..()
@@ -131,6 +135,8 @@
 	name = "egg box"
 	desc = "A carton for containing eggs."
 	spawn_type = /obj/item/food/egg
+	storage_max_columns = 6
+	storage_max_rows = 2
 
 /obj/item/storage/fancy/egg_box/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/sixpack.dm
+++ b/code/game/objects/items/storage/sixpack.dm
@@ -8,6 +8,8 @@
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	custom_materials = list(/datum/material/plastic = 1200)
 	max_integrity = 500
+	storage_max_columns = 3
+	storage_max_rows = 2
 
 /obj/item/storage/cans/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins popping open a final cold one with the boys! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -6,10 +6,11 @@
 	var/component_type = /datum/component/storage/concrete
 
 	//WoD13 vars start here :3
-
-	var/grid = TRUE /// Determines whether the container uses grid-based inventory.
+	/// Determines whether the container uses grid-based inventory. Cant find anything acctually using this.
+	var/grid = TRUE
+	var/storage_max_columns
+	var/storage_max_rows
 	var/storage_flags = NONE /// Flags determining how the storage can be accessed.
-
 	//WoD13 vars end here :3
 
 /obj/item/storage/get_dumping_location(obj/item/storage/source,mob/user)
@@ -20,7 +21,8 @@
 	PopulateContents()
 
 /obj/item/storage/ComponentInitialize()
-	AddComponent(component_type)
+	//Storage shouldnt even be a component in this first place, tg handles it with a datum, you should tweak vars via init args not subtypes, yet here we are.
+	AddComponent(component_type, null, _screen_max_columns = storage_max_columns, _screen_max_rows = storage_max_rows)
 
 /obj/item/storage/AllowDrop()
 	return FALSE

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -21,6 +21,8 @@
 	var/latches = "single_latch"
 	var/has_latches = TRUE
 	wound_bonus = 5
+	storage_max_columns = 5
+	storage_max_rows = 3
 
 /obj/item/storage/toolbox/Initialize()
 	. = ..()
@@ -79,7 +81,6 @@
 	new /obj/item/wrench(src)
 	new /obj/item/weldingtool(src)
 	new /obj/item/crowbar(src)
-	new /obj/item/analyzer(src)
 	new /obj/item/wirecutters(src)
 
 /obj/item/storage/toolbox/mechanical/old

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -7,6 +7,9 @@
 	slot_flags = ITEM_SLOT_ID
 	component_type = /datum/component/storage/concrete/wallet
 
+	storage_max_columns = 4
+	storage_max_rows = 1
+
 	var/obj/item/card/id/front_id = null
 	var/list/combined_access
 	var/cached_flat_icon

--- a/code/modules/vtmb/gridventory.dm
+++ b/code/modules/vtmb/gridventory.dm
@@ -79,12 +79,14 @@ VENTORY!
 	screen_max_rows = 4
 
 /datum/component/storage/concrete/vtm/car
+	max_w_class = WEIGHT_CLASS_HUGE
 	screen_max_columns = 7
 	screen_max_rows = 9
 
 /datum/component/storage/concrete/vtm/car/track
-	screen_max_columns = 12
-	screen_max_rows = 12
+	max_w_class = WEIGHT_CLASS_GIGANTIC
+	screen_max_columns = 13
+	screen_max_rows = 9
 
 /datum/component/storage/concrete/vtm/sheathe
 	screen_max_columns = 2
@@ -105,7 +107,7 @@ VENTORY!
 		'sound/effects/rustle5.ogg',
 	)
 	/// Exactly what it sounds like, this makes it use the new RE4-like inventory system
-	var/grid = FALSE
+	var/grid = TRUE
 	var/static/grid_box_size
 	var/static/list/mutable_appearance/underlay_appearances_by_size = list()
 	var/list/grid_coordinates_to_item
@@ -116,11 +118,12 @@ VENTORY!
 /obj/item/storage/ComponentInitialize() //backpacks are smaller but hold larger things
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	// ! THESE SHOULD BE ARGS YOU PASS INTO ADDCOMPONENT
 	STR.max_w_class = WEIGHT_CLASS_HUGE
 	STR.max_items = 40 //max grid
 	STR.max_combined_w_class = 100
 
-/datum/component/storage/Initialize(datum/component/storage/concrete/master)
+/datum/component/storage/Initialize(datum/component/storage/concrete/master, _screen_max_columns, _screen_max_rows)
 	if(!grid_box_size)
 		grid_box_size = world.icon_size
 	. = ..()


### PR DESCRIPTION
Ports https://github.com/ApocryphaXIII/ApocryphaXIII/pull/22

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports a rework and nerf to Boxifixation

## Why It's Good For The Game

Now you only get marginal gains for your inventory management boxes, that aren't specialized like IFAK. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="595" height="735" alt="dreamseeker_8xXyr3GipP" src="https://github.com/user-attachments/assets/00caf5a3-f9ee-474a-992c-daef0d81c199" />
<img width="506" height="566" alt="dreamseeker_0SBCLnHMMD" src="https://github.com/user-attachments/assets/7a723178-aa53-4103-abc4-72715d80dcc0" />
<img width="477" height="386" alt="dreamseeker_bcOw6ST85p" src="https://github.com/user-attachments/assets/94dd607f-6f0d-4088-801c-dbbff00ff95a" />
<img width="468" height="438" alt="dreamseeker_yAJGuKIpsj" src="https://github.com/user-attachments/assets/a29b1734-3701-4746-834e-c572529ee543" />
<img width="1913" height="1367" alt="dreamseeker_CPXJvFsxN4" src="https://github.com/user-attachments/assets/61282c99-f3cd-4b44-9045-9051d16a9119" />
<img width="1913" height="1367" alt="dreamseeker_VJzGFIpaod" src="https://github.com/user-attachments/assets/908398b8-7e0a-4f8e-9746-175aa6353cee" />
<img width="1913" height="1367" alt="dreamseeker_S2O4hENpRm" src="https://github.com/user-attachments/assets/8820113d-7295-442f-b571-416c37a4f843" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

::cl: SoreYew, FalloutFalcon
bugfix: Trucks are slightly improved
balance: Boxes are rebalanced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
