### PR TITLE
Fixes Slapping Tables

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -17,7 +17,7 @@
 	if (is_right_clicking)
 		switch (pre_attack_secondary(target, user, params))
 			if (SECONDARY_ATTACK_CALL_NORMAL)
-				pre_attack_result = pre_attack(src, user, params)
+				pre_attack_result = pre_attack(target, user, params)
 			if (SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 				return TRUE
 			if (SECONDARY_ATTACK_CONTINUE_CHAIN)
@@ -25,7 +25,7 @@
 			else
 				CRASH("pre_attack_secondary must return an SECONDARY_ATTACK_* define, please consult code/__DEFINES/combat.dm")
 	else
-		pre_attack_result = pre_attack(src, user, params)
+		pre_attack_result = pre_attack(target, user, params)
 
 	if(pre_attack_result)
 		return TRUE

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -265,12 +265,13 @@
 	playsound(slapped, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
 	return
 
-/obj/item/hand_item/slapper/pre_attack(atom/target, mob/living/user, params)
-	if(!loc.Adjacent(target) || !istype(target, /obj/structure/table))
-		return ..()
+/obj/item/hand_item/slapper/afterattack(atom/target, mob/living/user, proximity_flag, click_parameters)
+    if(proximity_flag && istype(target, /obj/structure/table))
+        slap_table(target, user)
+        return
 
-	slap_table(target, user)
-	return TRUE
+    return ..()
+
 
 /// Slap the table, get some attention
 /obj/item/hand_item/slapper/proc/slap_table(obj/structure/table/table, mob/living/user)

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -265,14 +265,12 @@
 	playsound(slapped, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
 	return
 
-//TFN EDIT START - Fixes Slamming Tables
-/obj/item/hand_item/slapper/afterattack(atom/target, mob/living/user, proximity_flag, click_parameters)
-    if(proximity_flag && istype(target, /obj/structure/table))
-        slap_table(target, user)
-        return
+/obj/item/hand_item/slapper/pre_attack(atom/target, mob/living/user, params)
+	if(!loc.Adjacent(target) || !istype(target, /obj/structure/table))
+		return ..()
 
-    return ..()
-//TFN EDIT END - Fixes Slamming Tables
+	slap_table(target, user)
+	return TRUE
 
 /// Slap the table, get some attention
 /obj/item/hand_item/slapper/proc/slap_table(obj/structure/table/table, mob/living/user)

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -265,13 +265,14 @@
 	playsound(slapped, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
 	return
 
+//TFN EDIT START - Fixes Slamming Tables
 /obj/item/hand_item/slapper/afterattack(atom/target, mob/living/user, proximity_flag, click_parameters)
     if(proximity_flag && istype(target, /obj/structure/table))
         slap_table(target, user)
         return
 
     return ..()
-
+//TFN EDIT END - Fixes Slamming Tables
 
 /// Slap the table, get some attention
 /obj/item/hand_item/slapper/proc/slap_table(obj/structure/table/table, mob/living/user)


### PR DESCRIPTION
## About The Pull Request

This PR fixes table slapping, something which if you do in-game now, doesnt play the sound. This fix plays the sound. From my debugging it looks like the atom/target from pre_attack was always src, the slapper object itself, but the atom/target from afterattack was correctly being registered as the table. I just changed the pre_attack to afterattack to solve this problem, the logic is unchanged besides this.

## Why It's Good For The Game

Fixing broken feature

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/ace4471c-6c7c-45bf-9e08-06340d51a1e7



## Changelog

:cl:

bugfix: using *slap on a table now correctly slams the table and plays the noise, previously wasnt working

/:cl:

