### PR TITLE
Makes pliers not into detectors.

### DIFF
--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -87,8 +87,6 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
-	if(!iskindred(target))
-		return
 	if(HAS_TRAIT(target, TRAIT_BABY_TEETH))
 		visible_message(usr, span_warning("[user] can't pull out the fangs of [target] because they are already deformed!"))
 	else
@@ -98,6 +96,9 @@
 		user.do_attack_animation(target)
 		user.visible_message(span_warning("[user] rips out [target]'s fangs!"), span_warning("You rip out [target]'s fangs!"))
 		target.emote("scream")
+		if(!iskindred(target))
+			target.apply_damage(80,BRUTE)
+			return
 		if(target.has_quirk(/datum/quirk/permafangs))
 			REMOVE_TRAIT(target, TRAIT_PERMAFANGS, ROUNDSTART_TRAIT)
 		if (permanent == TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Please stop abusing my items and use them for what they were made for. I've made this at 0230 and it causes me sadness that it even happened. This PR keeps haunting me.

## Why It's Good For The Game
People can't abuse the pliers as detectors anymore before they commit to it and cause damage to their victim and with the bad pliers there isn't even a difference.


## Testing Photographs and Procedure
<details>
<img width="508" height="294" alt="image" src="https://github.com/user-attachments/assets/f39b587d-60a9-4d66-b4cc-4a3f955c8742" />

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog



:cl:
fix: Makes it harder to detect if peeps are Vampires when using Pliers.
/:cl:


