### PR TITLE
Updating Prince to the 7 Clans of the Camarilla

### DIFF
--- a/code/modules/vtmb/jobs/prince.dm
+++ b/code/modules/vtmb/jobs/prince.dm
@@ -30,7 +30,7 @@
 
 	minimal_masquerade = 5
 	allowed_species = list("Vampire")
-	allowed_bloodlines = list(CLAN_TREMERE, CLAN_VENTRUE, CLAN_NOSFERATU, CLAN_TOREADOR, CLAN_MALKAVIAN, CLAN_BRUJAH, CLAN_LASOMBRA, CLAN_GANGREL, CLAN_TRUE_BRUJAH)
+	allowed_bloodlines = list(CLAN_TREMERE, CLAN_VENTRUE, CLAN_NOSFERATU, CLAN_TOREADOR, CLAN_MALKAVIAN, CLAN_LASOMBRA, CLAN_BANU_HAQIM)
 
 	known_contacts = list(
 		"Sheriff",


### PR DESCRIPTION
## About The Pull Request
To comply with existing lore precedent, Brujah and True Brujah have been removed from Prince. Brujah for no longer being a clan in the Camarilla, and True Brujah for this, and as well, the future narrative to quantify round based princes does not have room for exotic bloodlines. Banu Haqim have been added. Welcome to the deep end, Ass*mites.

In preparation for future features and metaplot trappings, Gangrel has been removed, so it is _only_ the Camarilla clans.

## Why It's Good For The Game
A part of clan identity can be the roles that the oppressive elders of the Camarilla allow others to possess. 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="204" height="61" alt="B68LimnLFV" src="https://github.com/user-attachments/assets/d4307828-8f84-440f-8b98-d39ba9bb0935" />
<img width="607" height="216" alt="pKmVj3UWJj" src="https://github.com/user-attachments/assets/1fdadbc0-dde2-4a1f-80f9-4b5d52ea65e9" />
<img width="167" height="51" alt="3FATbcTUYL" src="https://github.com/user-attachments/assets/276acad0-07e8-49ce-ae2d-43b4d02be7e3" />

</details>

## Changelog
:cl:
balance: rebalances prince role
/:cl:
