### PR TITLE
Baali Fancy Plating Bugfix

### DIFF
--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -176,7 +176,7 @@ SUBSYSTEM_DEF(traumas)
 		"aliens" = typecacheof(list(/turf/open/floor/plating/abductor, /turf/open/floor/plating/abductor2,
 			/turf/open/floor/mineral/abductor, /turf/closed/wall/mineral/abductor
 		)),
-		"security" = typecacheof(list(/turf/open/floor/plating/church, /turf/open/floor/plating/saint)),
+		//TFN Removal - Baali Fancy Plating Bugfix - Original Line : 	Line 179 : 	"security" = typecacheof(list(/turf/open/floor/plating/church, /turf/open/floor/plating/saint)),
 		"falling" = typecacheof(list(/turf/open/chasm, /turf/open/floor/fakepit))
 	)
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes a big that was reported by Baali players who noticed that seeing 'fancy plating' tiles would cause their characters to freak out, a dead giveaway of being a Baali, one of the most hated and hunted clans. The intent is for them to have fear of religious paraphernalia, but the use of 'church' tiles around the map has caused them to experience this issue. This PR removes the two turfs from the phobias list for the Baali's subtyped 'security' phobia, which is called 'religious trauma' or something.

## Why It's Good For The Game

bugfix

## Testing Photographs and Procedure
<img width="1309" height="802" alt="dreamseeker_rvmRyqMgcn" src="https://github.com/user-attachments/assets/265106ea-f184-41fa-88cc-d60582690151" />

<img width="1080" height="663" alt="dreamseeker_LnWbpLiGXa" src="https://github.com/user-attachments/assets/89acd22f-d580-4eb3-b540-7d475fe4fc3c" />
(i posessed a transformer because i got stuck using the jump to area verb)
the fancy plating is under the bush in this image

<img width="1223" height="665" alt="dreamseeker_u4bYWwO72I" src="https://github.com/user-attachments/assets/7f874cb3-8688-4021-b2e8-83f33930bf08" />
(but went back to make sure i was thoroughly testing!)
the fancy plating is under the bush in this image
## Changelog

:cl:

bugfix: Baalis no longer fear certain floor tiles.

/:cl:
