### PR TITLE
La Famiglia Sposarsi

### DIFF
--- a/code/modules/vtmb/jobs/giovanni.dm
+++ b/code/modules/vtmb/jobs/giovanni.dm
@@ -70,7 +70,7 @@
 	minimal_masquerade = 0
 	experience_addition = 10
 	allowed_species = list("Vampire")
-	allowed_bloodlines = list(CLAN_GIOVANNI, CLAN_CAPPADOCIAN)
+	allowed_bloodlines = list(CLAN_GIOVANNI)
 
 /datum/outfit/job/giovanni
 	name = "La Squadra"
@@ -100,7 +100,7 @@
 	faction = "Vampire"
 	total_positions = 10
 	spawn_positions = 10
-	supervisors = "the Family"
+	supervisors = "the Family or your Spouse"
 	selection_color = "#cb4aad"
 
 	outfit = /datum/outfit/job/giovannimafia
@@ -114,8 +114,9 @@
 
 //	minimal_generation = 11	//Uncomment when players get exp enough
 
-	allowed_species = list("Ghoul", "Human")
-	duty = "Your family is a strange one. Maybe you are strange too, because sitting next to your great uncles as an equal is something you are greatly interested in."
+	allowed_species = list("Ghoul", "Human", "Vampire")
+	allowed_bloodlines = list(CLAN_BRUJAH, CLAN_VENTRUE, CLAN_NOSFERATU, CLAN_GANGREL, CLAN_TOREADOR, CLAN_MALKAVIAN, CLAN_LASOMBRA)
+	duty = "Your family is a strange one. You might've married in, or just been given the short straw by God. But remember, family always looks out for each other."
 	minimal_masquerade = 0
 	experience_addition = 10
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Open La Famiglia open up to CLAN_BRUJAH, CLAN_VENTRUE, CLAN_NOSFERATU, CLAN_GANGREL, CLAN_TOREADOR, CLAN_MALKAVIAN, CLAN_LASOMBRA for those who marry into the Giovanni.

Also boot off Cappadocian from Squadra, their curse is not the same as Cold Aura.

## Why It's Good For The Game

More RP opportunities.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: select vampire clans to La Famiglia role
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
