### PR TITLE
Making Heist Loot Sellable

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -64,6 +64,14 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.15
 	armor_modifiers = list(MELEE = 1.1, BULLET = 1.1, LASER = 1.15, ENERGY = 1.15, BOMB = 1, BIO = 1, RAD = 1, FIRE = 0.7, ACID = 1.1)
 
+//TFN EDIT ADDITION - Making Heist Loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+/obj/item/stack/sheet/mineral/gold/Initialize()
+	. = ..()
+	// Always add selling component for gold sheets if they don't have one
+	if(!GetComponent(/datum/component/selling))
+		AddComponent(/datum/component/selling, 100, "precious_metals", FALSE)
+//TFN EDIT END - Making Heist loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+
 /datum/material/gold/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
 	return TRUE
@@ -80,6 +88,17 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.25
 	beauty_modifier = 0.3
 	armor_modifiers = list(MELEE = 1.3, BULLET = 1.3, LASER = 0.6, ENERGY = 1, BOMB = 1.2, BIO = 1, RAD = 1, FIRE = 1, ACID = 1)
+
+//TFN EDIT ADDITION - Making Heist Loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+/obj/item/stack/sheet/mineral/diamond/Initialize()
+	. = ..()
+	// Check if it's a named unique diamond
+	if(name == "The Heart Diamond" || name == "The Crown Diamond")
+		if(cost) // Use the cost value from the map
+			AddComponent(/datum/component/selling, cost, "precious_gems", FALSE)
+	else
+		AddComponent(/datum/component/selling, 1000, "precious_gems", FALSE)
+//TFN EDIT END - Making Heist loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
 
 /datum/material/diamond/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -64,12 +64,12 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.15
 	armor_modifiers = list(MELEE = 1.1, BULLET = 1.1, LASER = 1.15, ENERGY = 1.15, BOMB = 1, BIO = 1, RAD = 1, FIRE = 0.7, ACID = 1.1)
 
-//TFN EDIT ADDITION - Making Heist Loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+//TFN EDIT ADDITION - Making Heist Loot Sellable
 /obj/item/stack/sheet/mineral/gold/Initialize()
 	. = ..()
 	if(!GetComponent(/datum/component/selling))
 		AddComponent(/datum/component/selling, 100, "precious_metals", FALSE)
-//TFN EDIT END - Making Heist loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+//TFN EDIT END - Making Heist loot Sellable
 
 /datum/material/gold/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(10, BRUTE, BODY_ZONE_HEAD, wound_bonus = 5)
@@ -88,16 +88,16 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.3
 	armor_modifiers = list(MELEE = 1.3, BULLET = 1.3, LASER = 0.6, ENERGY = 1, BOMB = 1.2, BIO = 1, RAD = 1, FIRE = 1, ACID = 1)
 
-//TFN EDIT ADDITION - Making Heist Loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+//TFN EDIT ADDITION - Making Heist Loot Sellable -- note : The unique named items have their own 'cost' var which is supposed to represent their sell value.
 /obj/item/stack/sheet/mineral/diamond/Initialize()
 	. = ..()
-	// Check if it's a named unique diamond
+	// check if it's a named unique diamond
 	if(name == "The Heart Diamond" || name == "The Crown Diamond")
-		if(cost) // Use the cost value from the map
+		if(cost) // the unique items have been varedited to have their unique value as a var called 'cost'
 			AddComponent(/datum/component/selling, cost, "precious_gems", FALSE)
 	else
 		AddComponent(/datum/component/selling, 1000, "precious_gems", FALSE)
-//TFN EDIT END - Making Heist loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
+//TFN EDIT END - Making Heist loot Sellable
 
 /datum/material/diamond/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -67,7 +67,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 //TFN EDIT ADDITION - Making Heist Loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits
 /obj/item/stack/sheet/mineral/gold/Initialize()
 	. = ..()
-	// Always add selling component for gold sheets if they don't have one
 	if(!GetComponent(/datum/component/selling))
 		AddComponent(/datum/component/selling, 100, "precious_metals", FALSE)
 //TFN EDIT END - Making Heist loot Sellable -- note : the items are initialized onto the map as stacks, and so this logic handles for that, this needs to be changed if these unique items change / disappear from map edits

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -11,6 +11,12 @@
 	layer = MOB_LAYER
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+//TFN EDIT ADDITION - Making Heist Loot Sellable
+/obj/item/documents/Initialize()
+	. = ..()
+	AddComponent(/datum/component/selling, 500, "documents", FALSE)
+//TFN EDIT ADDITION - Making Heist Loot Sellable
+
 /obj/item/documents/nanotrasen
 	desc = "\"Top Secret\" Nanotrasen documents, filled with complex diagrams and lists of names, dates and coordinates."
 	icon_state = "docs_verified"
@@ -35,6 +41,12 @@
 	desc = "A copy of some top-secret documents. Nobody will notice they aren't the originals... right?"
 	var/forgedseal = 0
 	var/copy_type = null
+
+//TFN EDIT ADDITION - Making Heist Loot Sellable
+/obj/item/documents/photocopy/Initialize()
+	.=..()
+	AddComponent(/datum/component/selling, 20, "documents", FALSE)
+//TFN EDIT ADDITION - Making Heist Loot Sellable
 
 /obj/item/documents/photocopy/New(loc, obj/item/documents/copy=null)
 	..()

--- a/code/modules/wod13/clock.dm
+++ b/code/modules/wod13/clock.dm
@@ -17,7 +17,11 @@
 
 /obj/item/cockclock/Initialize()
 	. = ..()
-	AddComponent(/datum/component/selling, 50, "watch", FALSE)
+	if(name == "\improper dolex wrist watch")
+		if(cost) // Use the cost value from the map
+			AddComponent(/datum/component/selling, cost, "luxury_goods", FALSE)
+	else
+		AddComponent(/datum/component/selling, 50, "watch", FALSE)
 
 /obj/item/cockclock/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR makes heist loot sellable from the Bianchi Bank vault as well as 'secret documents' and other unique heist loot from across the map. It does this by initializing the items with selling components and changes the logic for the shop counter to handle stacks of items (such as the gold/diamond stacks since the items themselves are spawned as stacks). 

This PR will allow you to sell such heist loot such as secret documents, diamonds and gold, and the 'improper dolex watch' to the pawn shop.

This PR also simplifies the logic for generating money from shopcounters.

## Why It's Good For The Game

it was intended for these to be sold

## Testing Photographs and Procedure

https://github.com/user-attachments/assets/c9528058-b63d-4372-8b46-d56417a6ec9a

## Changelog
:cl:
add: heist loot such as gold, diamonds, and secret documents can now be sold at the pawn shop
/:cl:


