### PR TITLE
removes mcluskys

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -867,18 +867,6 @@
 /obj/structure/table/wood/fancy/royalblack,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/setite/basement)
-"alH" = (
-/obj/structure/guncase{
-	anchored = 1
-	},
-/obj/item/gun/ballistic/automatic/vampire/deagle/c50{
-	name = "Rebellion";
-	desc = "An extremely powerful, and rare, handcannon. This one seems to bolster silver engravings with anti-authority sentiments."
-	},
-/obj/item/ammo_box/magazine/m50,
-/obj/item/ammo_box/magazine/m50,
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/anarch/basement)
 "alM" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -28943,12 +28931,6 @@
 /obj/effect/decal/coastline,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/interior/cog/caern)
-"hBb" = (
-/obj/structure/table,
-/obj/item/gun/ballistic/automatic/pistol/deagle,
-/obj/item/ammo_box/magazine/m50/ctf,
-/turf/open/floor/plating/concrete,
-/area/vtm/supply)
 "hBe" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry/basement)
@@ -50957,15 +50939,6 @@
 /obj/machinery/light/prince{
 	pixel_y = 32
 	},
-/obj/item/gun/ballistic/automatic/vampire/deagle/c50{
-	name = "Compliance";
-	color = "#B2A9A9";
-	desc = "An extremely powerful, and rare, handcannon. This one seems to bolster gold engravings with pro-authority sentiments."
-	},
-/obj/item/ammo_box/magazine/m50,
-/obj/item/ammo_box/magazine/m50,
-/obj/item/ammo_box/magazine/m50,
-/obj/item/ammo_box/vampire/c50,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower/f2)
 "mVH" = (
@@ -131847,7 +131820,7 @@ skm
 niE
 eGb
 gnR
-alH
+tFd
 tFd
 tFd
 tFd
@@ -135882,7 +135855,7 @@ lFj
 bkQ
 azZ
 lUq
-hBb
+fLI
 fLI
 qur
 eku

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -91708,6 +91708,13 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/baywalk)
+"xtV" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/vampire/deagle,
+/obj/item/ammo_box/magazine/m44,
+/obj/item/ammo_box/magazine/m44,
+/turf/open/floor/plating/concrete,
+/area/vtm/supply)
 "xuj" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -131820,7 +131827,7 @@ skm
 niE
 eGb
 gnR
-tFd
+aGe
 tFd
 tFd
 tFd
@@ -135855,7 +135862,7 @@ lFj
 bkQ
 azZ
 lUq
-fLI
+xtV
 fLI
 qur
 eku


### PR DESCRIPTION

## About The Pull Request
removes every .50 cal deagle/mclusky from the map
## Why It's Good For The Game
hair trigger
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>
<img width="151" height="160" alt="kill1" src="https://github.com/user-attachments/assets/cb0bec56-5851-47ed-b32e-6dfc0739a415" />
<img width="188" height="169" alt="kill2" src="https://github.com/user-attachments/assets/4d5fddca-edfc-4730-bf4e-3ebe533e1049" />
<img width="130" height="169" alt="kill3" src="https://github.com/user-attachments/assets/2a87625c-d0b0-438c-a11d-a206bf84be2b" />

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:

del: Removed all mcluskys on the map

/:cl:
