### PR TITLE
Abyss Ritual: Reflections of Hollow Revelation

### DIFF
--- a/code/modules/vtmb/magic/mysticism.dm
+++ b/code/modules/vtmb/magic/mysticism.dm
@@ -198,16 +198,21 @@
 	name = "Reflections of Hollow Revelation"
 	desc = "Use a conjured Nocturne to spy on a target through nearby shadows"
 	icon_state = "teleport"
-	word = "VISION'LEJANA"
+	word = ""
 	mystlevel = 4
 	var/datum/action/close_window/end_action
 	var/mob/living/nocturne_user
 	var/obj/shadow_window/shadow_window
 	var/mob/living/carbon/human/window_target
+	var/isactive = FALSE
 
 /obj/abyssrune/reflections_of_hollow_revelation/complete()
 	var/mob/living/user = usr
 	if(!user)
+		return
+
+	if(isactive)
+		to_chat(user, span_warning("This Nocturne is already in use!"))
 		return
 
 	// Target input
@@ -215,6 +220,8 @@
 	if(!target_name || !user.Adjacent(src))
 		to_chat(user, span_warning("You must specify a target and remain close to the rune!"))
 		return
+
+	user.say("VISTA'DE'SOMBRA")
 
 	// Find the target
 	for(var/mob/living/carbon/human/targ in GLOB.player_list)
@@ -232,6 +239,7 @@
 	if (roll_result == ROLL_SUCCESS)
 		scry_target(window_target, user)
 		playsound(user, 'sound/magic/voidblink.ogg', 50, FALSE)
+		isactive = TRUE
 	else if(roll_result == ROLL_FAILURE)
 		qdel(src)
 		to_chat(user, span_warning("The Nocturne collapses!"))
@@ -268,11 +276,10 @@
 	to_chat(user, span_notice("You peer through the shadows near [target.name]..."))
 
 	RegisterSignal(user, COMSIG_MOB_RESET_PERSPECTIVE, PROC_REF(on_end))
-	addtimer(CALLBACK(src, PROC_REF(on_end),user), 3000) // 5 minute timer, AKA 1 Scene
+	addtimer(CALLBACK(src, PROC_REF(on_end),user), 1 SCENES) // 3 minute timer, AKA 1 Scene
 
 /obj/abyssrune/reflections_of_hollow_revelation/proc/shadowview(mob/target, mob/user)
 	nocturne_user = user
-	user.anchored = TRUE
 	user.notransform = TRUE
 
 	// Create camera
@@ -308,7 +315,6 @@
 	if(!user)
 		return
 
-	user.anchored = FALSE
 	user.notransform = FALSE
 
 	if(user.client?.eye != user)

--- a/code/modules/vtmb/magic/mysticism.dm
+++ b/code/modules/vtmb/magic/mysticism.dm
@@ -193,3 +193,182 @@
 	TIMER_COOLDOWN_START(invoker, COOLDOWN_RITUAL_INVOKE, 30 SECONDS)
 	playsound(rune_location, 'sound/magic/voidblink.ogg', 50, FALSE)
 	qdel(src)
+
+/obj/abyssrune/reflections_of_hollow_revelation
+	name = "Reflections of Hollow Revelation"
+	desc = "Use a conjured Nocturne to spy on a target through nearby shadows"
+	icon_state = "teleport"
+	word = "VISION'LEJANA"
+	mystlevel = 4
+	var/datum/action/close_window/end_action
+	var/mob/living/nocturne_user
+	var/obj/shadow_window/shadow_window
+	var/mob/living/carbon/human/window_target
+
+/obj/abyssrune/reflections_of_hollow_revelation/complete()
+	var/mob/living/user = usr
+	if(!user)
+		return
+
+	// Target input
+	var/target_name = tgui_input_text(user, "Choose target name:", "Reflections of Hollow Revelation")
+	if(!target_name || !user.Adjacent(src))
+		to_chat(user, span_warning("You must specify a target and remain close to the rune!"))
+		return
+
+	// Find the target
+	for(var/mob/living/carbon/human/targ in GLOB.player_list)
+		if(targ.real_name == target_name)
+			window_target = targ
+			break
+
+	if(!window_target)
+		to_chat(user, span_warning("[target_name] not found."))
+		return
+
+	// Roll for success; Mentality + Social in place of Perception + Occult
+	var/mypower = (user.get_total_mentality() + user.get_total_social())
+	var/roll_result = SSroll.storyteller_roll(mypower, 7, FALSE, user)
+	if (roll_result == ROLL_SUCCESS)
+		scry_target(window_target, user)
+		playsound(user, 'sound/magic/voidblink.ogg', 50, FALSE)
+	else if(roll_result == ROLL_FAILURE)
+		qdel(src)
+		to_chat(user, span_warning("The Nocturne collapses!"))
+	else if(roll_result == ROLL_BOTCH)
+		qdel(src)
+		to_chat(user, span_warning("You feel drained..."))
+		user.additional_athletics -= 2
+		user.additional_blood -= 2
+		user.additional_dexterity -= 2
+		user.additional_lockpicking -= 2
+		user.additional_mentality -= 2
+		user.additional_social -=2
+		addtimer(CALLBACK(src, PROC_REF(restore_stats), user), 1 SCENES)
+
+/obj/abyssrune/reflections_of_hollow_revelation/proc/restore_stats(mob/living/user)
+	if(user)
+		user.additional_athletics += 2
+		user.additional_blood += 2
+		user.additional_dexterity += 2
+		user.additional_lockpicking += 2
+		user.additional_mentality += 2
+		user.additional_social +=2
+
+/obj/abyssrune/reflections_of_hollow_revelation/proc/scry_target(mob/living/carbon/human/target, mob/user)
+	// If the target has Obtenebration or Auspex, roll to see if they detect the shadows
+	if(iskindred(target))
+		var/datum/species/kindred/vampire = target.dna?.species
+		if(vampire && (vampire.get_discipline("Obtenebration") || vampire.get_discipline("Auspex")))
+			var/theirpower = (target.get_total_mentality() + target.get_total_social()) // Mentality + Social in place of Perception + Occult
+			if(SSroll.storyteller_roll(theirpower, 8, FALSE, user) == ROLL_SUCCESS)
+				to_chat(target, span_warning("You notice the nearby shadows flicker... something is watching you."))
+
+	shadowview(target, user)
+	to_chat(user, span_notice("You peer through the shadows near [target.name]..."))
+
+	RegisterSignal(user, COMSIG_MOB_RESET_PERSPECTIVE, PROC_REF(on_end))
+	addtimer(CALLBACK(src, PROC_REF(on_end),user), 3000) // 5 minute timer, AKA 1 Scene
+
+/obj/abyssrune/reflections_of_hollow_revelation/proc/shadowview(mob/target, mob/user)
+	nocturne_user = user
+	user.anchored = TRUE
+	user.notransform = TRUE
+
+	// Create camera
+	shadow_window = new(get_turf(target), src)
+	user.reset_perspective(shadow_window)
+
+	// Give button to end viewing
+	end_action = new(src)
+	end_action.Grant(user)
+
+	RegisterSignal(user, COMSIG_MOB_RESET_PERSPECTIVE, PROC_REF(on_end))
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(check_target_distance))
+
+	to_chat(user, span_notice("You are now viewing through the shadows. Use the 'End Scrying' action to stop."))
+
+/obj/abyssrune/reflections_of_hollow_revelation/proc/check_target_distance()
+	SIGNAL_HANDLER
+	if(!window_target || !shadow_window)
+		return
+
+	// Window closes when target leaves range
+	if(get_dist(window_target, shadow_window) > 7)
+		if(nocturne_user)
+			to_chat(nocturne_user, span_warning("The window closes as [window_target.name] moves away from the shadows."))
+		on_end(nocturne_user)
+
+/obj/abyssrune/reflections_of_hollow_revelation/proc/on_end(mob/user)
+	SIGNAL_HANDLER
+	if(user == nocturne_user)
+		close_window(user)
+
+/obj/abyssrune/reflections_of_hollow_revelation/proc/close_window(mob/user)
+	if(!user)
+		return
+
+	user.anchored = FALSE
+	user.notransform = FALSE
+
+	if(user.client?.eye != user)
+		user.reset_perspective()
+
+	if(end_action)
+		end_action.Remove(user)
+		QDEL_NULL(end_action)
+
+	if(window_target)
+		UnregisterSignal(window_target, COMSIG_MOVABLE_MOVED)
+
+	QDEL_NULL(shadow_window)
+	qdel(src)
+	UnregisterSignal(user, COMSIG_MOB_RESET_PERSPECTIVE)
+
+	nocturne_user = null
+	to_chat(user, span_notice("You stop viewing through your summoned Nocturne."))
+	playsound(user, 'sound/magic/ethereal_exit.ogg', 50, FALSE)
+
+// Camera object
+/obj/shadow_window
+	name = "Shadow"
+	desc = "A shadow..."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "shadow"
+	invisibility = INVISIBILITY_ABSTRACT
+	layer = CAMERA_STATIC_LAYER
+	var/obj/abyssrune/reflections_of_hollow_revelation/parent_rune
+
+/obj/shadow_window/Initialize(mapload, obj/abyssrune/reflections_of_hollow_revelation/rune)
+	. = ..()
+	parent_rune = rune
+
+/obj/shadow_window/Destroy()
+	if(parent_rune && parent_rune.shadow_window == src)
+		parent_rune.shadow_window = null
+	parent_rune = null
+	return ..()
+
+// Action button
+/datum/action/close_window
+	name = "End Scrying"
+	desc = "Stop viewing through the shadows"
+	icon_icon = 'icons/mob/actions/actions_silicon.dmi'
+	button_icon_state = "camera_off"
+	var/obj/abyssrune/reflections_of_hollow_revelation/parent_rune
+
+/datum/action/close_window/New(obj/abyssrune/reflections_of_hollow_revelation/rune)
+	..()
+	parent_rune = rune
+
+/datum/action/close_window/Trigger(trigger_flags)
+	if(!parent_rune || !usr)
+		return
+	parent_rune.close_window(usr)
+
+/datum/action/close_window/Remove(mob/user)
+	if(parent_rune && parent_rune.end_action == src)
+		parent_rune.end_action = null
+	parent_rune = null
+	. = ..()
+	qdel(src)

--- a/code/modules/wod13/datums/powers/discipline/obtenebration.dm
+++ b/code/modules/wod13/datums/powers/discipline/obtenebration.dm
@@ -165,13 +165,13 @@
 		return
 
 	if(istype(H.get_active_held_item(), /obj/item/mystic_tome))
-		var/list/shit = list()
+		var/list/rituals = list()
 		for(var/i in subtypesof(/obj/abyssrune))
 			var/obj/abyssrune/R = new i(owner)
 			if(R.mystlevel <= level)
-				shit += i
+				rituals += i
 			qdel(R)
-		var/ritual = input(owner, "Choose rune to draw:", "Mysticism") as null|anything in shit
+		var/ritual = tgui_input_list(owner, "Choose rune to draw:", "Mysticism", rituals, null)
 		if(ritual)
 			drawing = TRUE
 			if(do_after(H, 3 SECONDS * max(1, 5 - H.mentality), H))
@@ -183,18 +183,18 @@
 			else
 				drawing = FALSE
 	else
-		var/list/shit = list()
+		var/list/rituals = list()
 		for(var/i in subtypesof(/obj/abyssrune))
 			var/obj/abyssrune/R = new i(owner)
 			if(R.mystlevel <= level)
-				shit += i
+				rituals += i
 			qdel(R)
-		var/ritual = input(owner, "Choose rune to draw (You need a Mystic Tome to reduce random):", "Mysticism") as null|anything in list("???")
+		var/ritual = tgui_input_list(owner, "Choose rune to draw (You need a Mystic Tome to reduce random):", "Mysticism", list("???"))
 		if(ritual)
 			drawing = TRUE
 			if(do_after(H, 30*max(1, 5-H.mentality), H))
 				drawing = FALSE
-				var/rune = pick(shit)
+				var/rune = pick(rituals)
 				new rune(H.loc)
 				H.bloodpool = max(H.bloodpool - 2, 0)
 				if(H.CheckEyewitness(H, H, 7, FALSE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the Abyss Mysticism ritual, 'Reflections of Hollow Revelation'. Essentially, what this ritual does is open a 'window' (creates a camera) on the target character's tile, which lasts until closed by the user, until the target walks out of range of the window, or until 1 scene (3 minutes) has passed. The ritual requires a roll at diff 7 to activate; on failure, it simply does nothing, and on botch, it reduces the user's stats by 2 for 1 scene.

Currently uses sprites for both the rune and camera cancel that were just around... I think they work fine, but they can be changed to whatever else.

## Why It's Good For The Game

More TTRPG-accurate content is good!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="431" height="508" alt="brave_vBPN9dfz2z" src="https://github.com/user-attachments/assets/d12278c4-8329-4cb8-bd54-fafda3188959" />

https://github.com/user-attachments/assets/db8c4089-ec01-4532-96b9-73e95c4a2675

https://github.com/user-attachments/assets/4a504679-bcee-4ed2-8df9-fb8ce51c9fde

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a new Abyss Mysticism ritual: Reflections of Hollow Revelation
refactor: Refactors some Abyss Mysticism-related code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
