### PR TITLE
Adds robes to loadout

### DIFF
--- a/modular_tfn/modules/loadout/loadout_suit.dm
+++ b/modular_tfn/modules/loadout/loadout_suit.dm
@@ -86,6 +86,55 @@
 /datum/gear/suit/trenchcoat/burgundy
 	display_name = "trenchcoat, burgundy"
 	path = /obj/item/clothing/suit/vampire/trench/archive
+	
+//Robes
+/datum/gear/suit/hooded/robes
+	subtype_path = /datum/gear/suit/hooded/robes
+	
+/datum/gear/suit/hooded/robes/white
+	display_name = "white robe"
+	description = "Some angelic-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes
+	
+/datum/gear/suit/hooded/robes/black
+	display_name = "black robe"
+	description = "Some creepy-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/black
+	
+/datum/gear/suit/hooded/robes/grey
+	display_name = "grey robe"
+	description = "Some somber-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/grey
+	
+/datum/gear/suit/hooded/robes/darkred
+	display_name = "dark red robe"
+	description = "Some zealous-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/darkred
+	
+/datum/gear/suit/hooded/robes/yellow
+	display_name = "yellow robe"
+	description = "Some happy-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/yellow
+	
+/datum/gear/suit/hooded/robes/green
+	display_name = "green robe"
+	description = "Some earthy-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/green
+	
+/datum/gear/suit/hooded/robes/red
+	display_name = "red robe"
+	description = "Some furious-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/red
+	
+/datum/gear/suit/hooded/robes/purple
+	display_name = "purple robe"
+	description = "Some elegant-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/purple
+	
+/datum/gear/suit/hooded/robes/blue
+	display_name = "blue robe"
+	description = "Some watery-looking robes."
+	path = /obj/item/clothing/suit/hooded/robes/blue
 
 // Misc
 

--- a/modular_tfn/modules/loadout/loadout_suit.dm
+++ b/modular_tfn/modules/loadout/loadout_suit.dm
@@ -92,47 +92,47 @@
 	subtype_path = /datum/gear/suit/hooded/robes
 	
 /datum/gear/suit/hooded/robes/white
-	display_name = "white robe"
+	display_name = "robe, white"
 	description = "Some angelic-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes
 	
 /datum/gear/suit/hooded/robes/black
-	display_name = "black robe"
+	display_name = "robe, black"
 	description = "Some creepy-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/black
 	
 /datum/gear/suit/hooded/robes/grey
-	display_name = "grey robe"
+	display_name = "robe, grey"
 	description = "Some somber-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/grey
 	
 /datum/gear/suit/hooded/robes/darkred
-	display_name = "dark red robe"
+	display_name = "robe, dark red"
 	description = "Some zealous-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/darkred
 	
 /datum/gear/suit/hooded/robes/yellow
-	display_name = "yellow robe"
+	display_name = "robe, yellow"
 	description = "Some happy-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/yellow
 	
 /datum/gear/suit/hooded/robes/green
-	display_name = "green robe"
+	display_name = "robe, green"
 	description = "Some earthy-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/green
 	
 /datum/gear/suit/hooded/robes/red
-	display_name = "red robe"
+	display_name = "robe, red"
 	description = "Some furious-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/red
 	
 /datum/gear/suit/hooded/robes/purple
-	display_name = "purple robe"
+	display_name = "robe, purple"
 	description = "Some elegant-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/purple
 	
 /datum/gear/suit/hooded/robes/blue
-	display_name = "blue robe"
+	display_name = "robe, blue"
 	description = "Some watery-looking robes."
 	path = /obj/item/clothing/suit/hooded/robes/blue
 


### PR DESCRIPTION
## About The Pull Request

Adds the costume store robes to the starting loadout, simple as.


## Why It's Good For The Game

Figured that if you can get pretty much all the clothing store items in your loadout, the robes may as well be there too. I don't think that it'd invalidate the stores since, just like if you want to try out new outfits mid-round or have a costume party with your buddies, you'd still have to pay a visit. Plus the masks and other stuff they have aren't available anywhere else.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="1272" height="955" alt="image" src="https://github.com/user-attachments/assets/00452440-d806-4726-8361-0bc7e9bf8cea" />
<img width="1242" height="786" alt="image" src="https://github.com/user-attachments/assets/bd0370ce-7a8f-4ae9-8f79-1bb6e3b41582" />
<img width="893" height="588" alt="image" src="https://github.com/user-attachments/assets/433dc577-0b9e-4f0b-86a1-60a8754f287a" />
<img width="787" height="458" alt="image" src="https://github.com/user-attachments/assets/a8fae447-693e-4854-8294-c69657d05d8a" />
(All the other colors work perfectly fine, as intended. There's just 9 of them)

I have also tested adding and removing some of them from the list and it doesn't seem to have affected the rest of the purchased loadout stuff so we shouldn't have to worry about them getting wiped again.


</details>

## Changelog

:cl:
add: Added the standard robes to the character creation loadout
/:cl: