### PR TITLE
Fixing new players not able to open setup character

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -466,7 +466,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(CONFIG_GET(flag/roundstart_traits))
 				dat += "<center><h2>[make_font_cool("QUIRK SETUP")]</h2>"
 				dat += "<a href='byond://?_src_=prefs;preference=trait;task=menu'>Configure Quirks</a><br></center>"
-				dat += "<center><b>Current Quirks:</b> [all_quirks?.len ? all_quirks.Join(", ") : "None"]</center>"
+				dat += "<center><b>Current Quirks:</b> [all_quirks.len ? all_quirks.Join(", ") : "None"]</center>"
 			dat += "<h2>[make_font_cool("IDENTITY")]</h2>"
 			dat += "<table width='100%'><tr><td width='75%' valign='top'>"
 			if(is_banned_from(user.ckey, "Appearance"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -466,7 +466,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(CONFIG_GET(flag/roundstart_traits))
 				dat += "<center><h2>[make_font_cool("QUIRK SETUP")]</h2>"
 				dat += "<a href='byond://?_src_=prefs;preference=trait;task=menu'>Configure Quirks</a><br></center>"
-				dat += "<center><b>Current Quirks:</b> [all_quirks.len ? all_quirks.Join(", ") : "None"]</center>"
+				dat += "<center><b>Current Quirks:</b> [all_quirks?.len ? all_quirks.Join(", ") : "None"]</center>"
 			dat += "<h2>[make_font_cool("IDENTITY")]</h2>"
 			dat += "<table width='100%'><tr><td width='75%' valign='top'>"
 			if(is_banned_from(user.ckey, "Appearance"))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -827,7 +827,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["honor"]			, honor)
 	WRITE_FILE(S["glory"]			, glory)
 	WRITE_FILE(S["wisdom"]			, wisdom)
-	WRITE_FILE(S["clan"]			, clan?.type)
+	WRITE_FILE(S["clan"]			, clan.type)
 	WRITE_FILE(S["generation"]			, generation)
 	WRITE_FILE(S["generation_bonus"]			, generation_bonus)
 	WRITE_FILE(S["masquerade_score"] , masquerade_score)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -728,6 +728,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	all_quirks = SANITIZE_LIST(all_quirks)
 	validate_quirks()
+	if(!islist(all_quirks))
+		all_quirks = list()
 	// TFN EDIT ADDITION START: sanitize headshot
 	if(!valid_headshot_link(null, headshot_link, TRUE))
 		headshot_link = null
@@ -825,7 +827,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["honor"]			, honor)
 	WRITE_FILE(S["glory"]			, glory)
 	WRITE_FILE(S["wisdom"]			, wisdom)
-	WRITE_FILE(S["clan"]			, clan.type)
+	WRITE_FILE(S["clan"]			, clan?.type)
 	WRITE_FILE(S["generation"]			, generation)
 	WRITE_FILE(S["generation_bonus"]			, generation_bonus)
 	WRITE_FILE(S["masquerade_score"] , masquerade_score)


### PR DESCRIPTION
## About The Pull Request

This PR fixes a runtime that caused new players to be unable to open the setup character menu. 

<img width="600" height="400" alt="5RRtldYodh" src="https://github.com/user-attachments/assets/10efaa8b-0e6e-4ca8-851e-7ee6ae9ce017" />
<img width="600" height="400" alt="nHPSSbB3R1" src="https://github.com/user-attachments/assets/4f30f780-5f46-4698-86ea-2c35ea572ee7" />

a note - this pr does NOT, as far as I know, address the 'players not able to open occupation preferences menu' bug - show me the runtime and i'll check that one out

the runtimes were on line 469 of preferences.dm which was trying to access all_quirks but it was returning null (cannot read null.len), solved this by adding a nullcheck 'all_quirks.len' -> 'all_quirks?.len', as well as forcing it to import as an empty list from preferences_savefile, since thats the only place it could be becoming null since datum/preferences initializes it as an empty list

and preferences_savefile line 828 which was the 'write clan to savefile' line which it couldnt read null.type.  
## Why It's Good For The Game

new players couldnt play, this runtime fired whenever they clicked the button

## Testing Photographs and Procedure
im not certain how this was reproduced, but this is a screenshot of my dream daemon after opening a testserver and dicking around on setup character

<img width="374" height="183" alt="dreamdaemon_KQmi1soYpr" src="https://github.com/user-attachments/assets/bcf129f5-2842-4591-8764-0fba379dfc31" />


## Changelog

:cl:

bugfix: new players should now be able to open setup character

/:cl:

