### PR TITLE
Sabbat no longer show off as "WE ARE SABBAT" in the Crew Manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -231,7 +231,12 @@
 		else
 			assignment = "Unassigned"
 
-		// TFN EDIT START: alt job titles
+		// TFN EDIT START: alt job titles AND FOR SABBAT TO NOT BE SEEN!!!
+		var/list/sabbat_jobs = GLOB.sabbat_positions
+		if(H.mind.assigned_role in sabbat_jobs)
+			to_chat(world, "THE THING WORKED!!!!")
+			trueassignment = assignment
+			assignment = "Citizen"
 		if(C?.prefs?.alt_titles_preferences[assignment])
 			trueassignment = assignment
 			assignment = C.prefs.alt_titles_preferences[assignment]

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -234,7 +234,6 @@
 		// TFN EDIT START: alt job titles AND FOR SABBAT TO NOT BE SEEN!!!
 		var/list/sabbat_jobs = GLOB.sabbat_positions
 		if(H.mind.assigned_role in sabbat_jobs)
-			to_chat(world, "THE THING WORKED!!!!")
 			trueassignment = assignment
 			assignment = "Citizen"
 		if(C?.prefs?.alt_titles_preferences[assignment])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sabbat no longer show off as "WE ARE SABBAT" in the Crew Manifest

It just says Citizen now so no metagaming
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
DEATH TO METAGAMING!!!!!! IF YOU WANNA FIGURE OUT IF THEY SABBAT JOIN THE GAME RAARGH!!!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="395" height="190" alt="image" src="https://github.com/user-attachments/assets/ee0ed290-1fa6-454f-98ed-c9682bb812c4" />
<img width="350" height="447" alt="image" src="https://github.com/user-attachments/assets/5d54dff4-e9c1-4f2e-ba89-4ff21bd4d4aa" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a thing to make Sabbat be incognito in the Crew manifest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
