### PR TITLE
Allows most of the Garou to choose their Sept

### DIFF
--- a/code/modules/vtmb/jobs/garou/amberglade.dm
+++ b/code/modules/vtmb/jobs/garou/amberglade.dm
@@ -1,4 +1,4 @@
-#define AMBERGLADE_ALLOWED_TRIBES list("Galestalkers", "Ghost Council", "Hart Wardens", "Get of Fenris", "Black Furies", "Silent Striders", "Red Talons", "Silver Fangs", "Stargazers")
+#define AMBERGLADE_ALLOWED_TRIBES list("Galestalkers", "Ghost Council", "Hart Wardens", "Get of Fenris", "Black Furies", "Silent Striders", "Red Talons", "Silver Fangs", "Stargazers","Glass Walkers", "Bone Gnawers", "Children of Gaia", "Shadow Lords")
 
 /datum/job/vamp/garou/amberglade/council
 	title = "Amberglade Councillor"

--- a/code/modules/vtmb/jobs/garou/paintedcity.dm
+++ b/code/modules/vtmb/jobs/garou/paintedcity.dm
@@ -1,4 +1,4 @@
-#define PAINTED_CITY_TRIBES list("Glass Walkers", "Bone Gnawers", "Children of Gaia", "Shadow Lords")
+#define PAINTED_CITY_TRIBES list("Glass Walkers", "Bone Gnawers", "Children of Gaia", "Shadow Lords","Galestalkers", "Ghost Council", "Hart Wardens", "Get of Fenris", "Black Furies", "Silent Striders", "Red Talons", "Silver Fangs", "Stargazers")
 
 /datum/job/vamp/garou/paintedcity/council
 	title = "Painted City Councillor"


### PR DESCRIPTION

## About The Pull Request

This PR lets people play the Sept they prefer, regardless of their Tribe. It allows more creative freedom to the players, and lets people not feel like they are forced to be a specific Tribe if they wish to work in the Tech Shop or in the Forest

## Why It's Good For The Game

Due to the combined nature of the Septs, where there is a teleporter between them, it makes sense that people make friends with others. They may disagree with the political structure of one of the Septs, and, rather than just getting into an infinite loop of "Challenge, get ass kicked, die, wait for next round", this gives them options. While I'd expect anyone working with the other Sept to get some eyebrows raised, I believe that what is fun for players can sometimes run against White Wolf Lore, since... Well, you might've read it. The BSDs don't get this because.... I mean, come on. Same with the Corax. Sorry, Birbs

## Testing Photographs and Procedure

(https://i.gyazo.com/457488b60a005b988925b83b25ef14e4.png)



:cl:
code: Added Painted City tribes to Amberglade Allowed Tribes, added Amberglade tribes to Painted City Tribes
/:cl:

