### PR TITLE
Reduces Concussions

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -362,7 +362,7 @@
 							span_danger("[src] is knocked senseless!"),
 							span_userdanger("You're knocked senseless!"),
 						)
-						if(get_confusion() < 10 SECONDS) // TFN EDIT CHANGE - Lines 365 and 366 reduced timers from 20 SECONDS to 5 and 2 SECONDS, respectively.
+						if(get_confusion() < 10 SECONDS) // TFN EDIT CHANGE - Lines 365 and 366 reduced timers from 20 SECONDS to 10 and 5 SECONDS, respectively.
 							set_confusion(5 SECONDS)
 						adjust_blurriness(20 SECONDS)
 					if(prob(10))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -362,8 +362,8 @@
 							span_danger("[src] is knocked senseless!"),
 							span_userdanger("You're knocked senseless!"),
 						)
-						if(get_confusion() < 20 SECONDS)
-							set_confusion(20 SECONDS)
+						if(get_confusion() < 10 SECONDS) // TFN EDIT CHANGE - Lines 365 and 366 reduced timers from 20 SECONDS to 5 and 2 SECONDS, respectively.
+							set_confusion(5 SECONDS)
 						adjust_blurriness(20 SECONDS)
 					if(prob(10))
 						gain_trauma(/datum/brain_trauma/mild/concussion)

--- a/code/modules/wod13/datums/powers/discipline/bloodheal.dm
+++ b/code/modules/wod13/datums/powers/discipline/bloodheal.dm
@@ -59,6 +59,12 @@
 		brain.applyOrganDamage(-HEAL_BASHING_LETHAL * (vitae_cost*5))
 		brain.cure_all_traumas(TRAUMA_RESILIENCE_WOUND)
 
+	//clear confusion and dizziness from head trauma
+	owner.set_confusion(0)
+	owner.dizziness = 0
+	owner.eye_blurry = 0
+	owner.update_eye_blur()
+
 	//miscellaneous organ damage healing
 	var/obj/item/organ/eyes/eyes = owner.getorganslot(ORGAN_SLOT_EYES)
 	if (eyes)

--- a/code/modules/wod13/datums/powers/discipline/bloodheal.dm
+++ b/code/modules/wod13/datums/powers/discipline/bloodheal.dm
@@ -62,7 +62,6 @@
 	//clear confusion and dizziness from head trauma
 	owner.set_confusion(0)
 	owner.dizziness = 0
-	owner.eye_blurry = 0
 	owner.update_eye_blur()
 
 	//miscellaneous organ damage healing

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -681,7 +681,6 @@
 		visible_message("<span class='warning'>[user] bonks [src]'s head!</span>", "<span class='warning'>You bonk[target]'s head!</span>")
 		if(user.mind && is_sabbatist(user))
 			target.Stun(3 SECONDS)
-			target.emote("collapse")
 			target.drop_all_held_items()
 
 /obj/item/melee/vampirearms/katana/kosa

--- a/modular_tfn/modules/werewolf/gifts.dm
+++ b/modular_tfn/modules/werewolf/gifts.dm
@@ -384,6 +384,10 @@
 			C.adjustOxyLoss(-20*C.auspice.level, TRUE)
 			C.bloodpool = min(C.bloodpool + C.auspice.level, C.maxbloodpool)
 			C.blood_volume = min(C.blood_volume + 56 * C.auspice.level, BLOOD_VOLUME_NORMAL)
+			//clear confusion and dizziness from head trauma
+			C.set_confusion(0)
+			C.dizziness = 0
+			C.update_eye_blur()
 			if(ishuman(owner))
 				var/mob/living/carbon/human/BD = owner
 				if(length(BD.all_wounds))


### PR DESCRIPTION
## About The Pull Request

This PR reduces concussions. It does this by reducing the duration of the 'confusion' (mob moves in a random direction instead of intended direction from keyboard input) as well as allowing bloodheal to immediately cure the status effect of confusion as well as the eye blurriness. 

I have also snuck in a removal for the emote "collapse" from the Sabbat shovel, since it extended the stun by about 5 seconds when the original intent was for it to merely last 3 seconds.

## Why It's Good For The Game

Players really dont enjoy the concussions, there was a previous PR to remove them completely, https://github.com/The-Final-Nights/The-Final-Nights/pull/638, this PR reduces the effects and allows for bloodheal to cure it, instead of just outright removal.

## Testing Photographs and Procedure
before ("youre knocked senseless") is the message of a successful application of the concussion and eye blurriness
<img width="1221" height="887" alt="dreamseeker_PBDvmaUCqL" src="https://github.com/user-attachments/assets/5fd31f43-161b-4500-9c40-eb8157d5203f" />

after
<img width="1294" height="899" alt="dreamseeker_1ocYAwKWDy" src="https://github.com/user-attachments/assets/78dd6719-6566-4002-ae67-a2bd95c72a92" />



## Changelog


:cl:

balance: Reduces the effects of concussions as well as allows bloodheal to completely cure the concussive effects.
balance: The Sabbat Shovel no longer causes the emote "collapse" which extended the stun from 3 seconds to about 8 seconds, an unintended effect.

/:cl:


