### PR TITLE
Fixes Daughters of Cacophany being able to force people to say things.

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -292,7 +292,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 					EX.total_erp += length_char(message)
 
 	// Recompose message for AI hrefs, language incomprehension.
-	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
+	//message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods) //TFN EDIT, REMOVAL
 
 	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlighting = speaker == src)
 	return message

--- a/code/modules/wod13/datums/powers/discipline/__discipline_power.dm
+++ b/code/modules/wod13/datums/powers/discipline/__discipline_power.dm
@@ -49,6 +49,8 @@
 	var/list/grouped_powers
 	/// Group this Discipline belongs to. Only one discipline of a group may be active at a time. No cooldown is shared.
 	var/power_group = DISCIPLINE_POWER_GROUP_NONE
+	/// If the power has custom logging, for example Melpominee.
+	var/custom_logging = FALSE
 
 	/* NOT MEANT TO BE OVERRIDDEN */
 	/// Timer(s) tracking the duration of the power. Can have multiple if multi_activate is true.
@@ -449,7 +451,8 @@
 	INVOKE_ASYNC(src, PROC_REF(do_masquerade_violation), target)
 
 	do_caster_notification(target)
-	do_logging(target)
+	if(!custom_logging)
+		do_logging(target)
 
 	owner.update_action_buttons()
 

--- a/code/modules/wod13/datums/powers/discipline/melpominee.dm
+++ b/code/modules/wod13/datums/powers/discipline/melpominee.dm
@@ -20,9 +20,10 @@
 
 	level = 1
 	vitae_cost = 0
-	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_SPEAK
+	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_SPEAK | DISC_CHECK_DIRECT_SEE
 	target_type = TARGET_OBJ | TARGET_LIVING
 	range = 7
+	custom_logging = TRUE
 
 	cooldown_length = 5 SECONDS
 
@@ -44,6 +45,7 @@
 		return
 
 	target.melpominee_say(owner, message = new_say)
+	do_logging(target, new_say)
 
 	if (!isliving(target))
 		return
@@ -96,6 +98,9 @@
 			else
 				to_chat(hearer, span_warning("[target]'s lips aren't moving to match [target.p_their()] words."))
 
+/datum/discipline_power/melpominee/the_missing_voice/do_logging(target, message)
+	. = ..()
+	log_combat(owner, target, "Forced [target] to say [message]")
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/wod13/datums/powers/discipline/melpominee.dm
+++ b/code/modules/wod13/datums/powers/discipline/melpominee.dm
@@ -11,6 +11,8 @@
 
 	activate_sound = 'code/modules/wod13/sounds/melpominee.ogg'
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 //THE MISSING VOICE
 /datum/discipline_power/melpominee/the_missing_voice
 	name = "The Missing Voice"
@@ -26,14 +28,14 @@
 
 /datum/discipline_power/melpominee/the_missing_voice/activate(atom/movable/target)
 	. = ..()
-	var/new_say = input(owner, "What will [target] say?") as null|text
+	var/new_say = tgui_input_text(owner, "What will [target] say?")
 	if(!new_say)
 		return
 
 	//prevent forceful emoting and whatnot
 	new_say = trim(copytext_char(sanitize(new_say), 1, MAX_MESSAGE_LEN))
 	if (findtext(new_say, "*"))
-		to_chat(owner, span_danger("You can't force others to perform emotes!"))
+		to_chat(owner, span_danger("You can't perform emotes remotely!"))
 		return
 
 	if (CHAT_FILTER_CHECK(new_say))
@@ -41,11 +43,35 @@
 		SSblackbox.record_feedback("tally", "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
 		return
 
-	target.say(message = new_say, forced = "melpominee 1")
+	target.melpominee_say(owner, message = new_say)
 
 	if (!isliving(target))
 		return
 
+	speaker_mouth_check(target)
+
+/atom/movable/proc/melpominee_say(speaker, message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = TRUE)
+	if(!can_speak())
+		return
+	if(message == "" || !message)
+		return
+	spans |= speech_span
+	if(!language)
+		language = get_selected_language()
+
+	var/range = 7
+	var/list/message_mods = list()
+	var/ending = copytext_char(message, -1)	//Better not to do like that..
+	var/rendered = compose_message(speaker, language, message, , spans, message_mods)
+	if(ending == "!")
+		range = 15
+	for(var/_AM in get_hearers_in_view(range, src))
+		var/atom/movable/AM = _AM
+		if(get_dist(AM, src) > 7)
+			rendered = "<span class='scream_away'>[rendered]</span>" //! Take an attention, this will NOT overlap client font-size, fix it if you can
+		AM.Hear(rendered, src, language, message, , spans, message_mods)
+
+/datum/discipline_power/melpominee/proc/speaker_mouth_check(mob/living/target)
 	//viewers are able to detect if a person's words aren't their own
 	var/base_difficulty = 5
 	var/difficulty_malus = 0
@@ -69,6 +95,9 @@
 				to_chat(hearer, span_warning("[target]'s jaw isn't moving to match [target.p_their()] words."))
 			else
 				to_chat(hearer, span_warning("[target]'s lips aren't moving to match [target.p_their()] words."))
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //PHANTOM SPEAKER
 /datum/discipline_power/melpominee/phantom_speaker
@@ -104,6 +133,8 @@
 	target.Hear(message, target, language, input_message, , , )
 	to_chat(owner, span_notice("You project your voice to [target]'s ears."))
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 //MADRIGAL
 /datum/discipline_power/melpominee/madrigal
 	name = "Madrigal"
@@ -137,6 +168,9 @@
 	. = ..()
 	target.remove_overlay(MUTATIONS_LAYER)
 
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 //SIREN'S BECKONING
 /datum/discipline_power/melpominee/sirens_beckoning
 	name = "Siren's Beckoning"
@@ -166,6 +200,9 @@
 /datum/discipline_power/melpominee/sirens_beckoning/deactivate(mob/living/carbon/human/target)
 	. = ..()
 	target.remove_overlay(MUTATIONS_LAYER)
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //SHATTERING CRESCENDO
 /datum/discipline_power/melpominee/shattering_crescendo
@@ -197,3 +234,6 @@
 /datum/discipline_power/melpominee/shattering_crescendo/deactivate(mob/living/carbon/human/target)
 	. = ..()
 	target.remove_overlay(MUTATIONS_LAYER)
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+


### PR DESCRIPTION

## About The Pull Request
See title.

``The character can “throw” her voice anywhere with-
in her line of sight. This enables the Daughter to carry
on surreptitious conversations, sing duets with herself,
or cause any number of distractions``

## Why It's Good For The Game
Daughters of Cacophany arent supposed to force people to say things.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="1147" height="581" alt="image" src="https://github.com/user-attachments/assets/1efc9598-27f4-4b2a-b4e2-cb537a65efca" />

</details>

## Changelog
:cl:
fix: Fixed Daughters of Cacophany being able to force people to say things.
/:cl:
