### PR TITLE
Fixes Simplemob Transformations Losing Languages

### DIFF
--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -160,7 +160,6 @@
 				mind_holder.selected_language = backup_selected_language
 		//TFN EDIT ADDITION START - Fixes Simplemob Transformations Losing Languages
 
-
 	stored.forceMove(src)
 	stored.notransform = TRUE
 	if(source.convert_damage)

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -243,6 +243,7 @@
 dama_percentage = ( 1 (current HP) / 100 (max hp) ) = 0.002
 percent_carbon = 100 * 0.002 = 0.2
 gross_damage = 100 - 0.2 = 99.75
+
 Result: you take at least 90 damage when you trasnform back
 */
 		stored.apply_damage(gross_damage, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND)

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -127,6 +127,7 @@
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster
 
+	//TFN EDIT ADDITION START - Fixes Simplemob Transformations Losing Languages
 	// store language data
 	var/datum/language_holder/original_holder = stored.get_language_holder() //get_language_holder defaults to the mind language holder rather than the atom's
 	if(original_holder)
@@ -140,10 +141,12 @@
 			backup_spoken_languages += language
 
 		backup_selected_language = original_holder.selected_language
+	//TFN EDIT ADDITION START - Fixes Simplemob Transformations Losing Languages
 
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
 
+		//TFN EDIT ADDITION START - Fixes Simplemob Transformations Losing Languages
 		// Bring stored languages after transfer_to (transfer_to calls update_atom_languages() which will have cleared all languages from the mind since it draws from the atom's language holder)
 		var/datum/language_holder/mind_holder = shape.mind?.get_language_holder()
 		if(mind_holder && backup_understood_languages && backup_spoken_languages)
@@ -155,6 +158,8 @@
 
 			if(backup_selected_language && mind_holder.can_speak_language(backup_selected_language))
 				mind_holder.selected_language = backup_selected_language
+		//TFN EDIT ADDITION START - Fixes Simplemob Transformations Losing Languages
+
 
 	stored.forceMove(src)
 	stored.notransform = TRUE
@@ -217,6 +222,7 @@
 	if(shape.mind)
 		shape.mind.transfer_to(stored)
 
+		//TFN EDIT ADDITION START - Fixes Simplemob Transformations Losing Languages
 		// transfer_to calls update_atom_languages(), and the atom language holder doesn't store our languages from quirks, so restore from backup list created in Initialize()
 		var/datum/language_holder/restored_holder = stored.get_language_holder() //defaults to the mind language holder, if it exists
 		if(restored_holder && backup_understood_languages && backup_spoken_languages)
@@ -230,6 +236,7 @@
 
 			if(backup_selected_language)
 				restored_holder.selected_language = backup_selected_language
+		//TFN EDIT ADDITION END - Fixes Simplemob Transformations Losing Languages
 
 	if(death)
 		stored.death()

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -127,47 +127,32 @@
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster
 
-	// Backup language data BEFORE moving the caster anywhere
-	var/datum/language_holder/original_holder = stored.get_language_holder()
+	// store language data
+	var/datum/language_holder/original_holder = stored.get_language_holder() //get_language_holder defaults to the mind language holder rather than the atom's
 	if(original_holder)
 		backup_understood_languages = list()
 		backup_spoken_languages = list()
 
-		// Deep copy understood languages with their sources
 		for(var/language in original_holder.understood_languages)
-			var/list/sources = original_holder.understood_languages[language]
-			backup_understood_languages[language] = sources.Copy()
+			backup_understood_languages += language
 
-		// Deep copy spoken languages with their sources
 		for(var/language in original_holder.spoken_languages)
-			var/list/sources = original_holder.spoken_languages[language]
-			backup_spoken_languages[language] = sources.Copy()
+			backup_spoken_languages += language
 
 		backup_selected_language = original_holder.selected_language
-
-		backup_selected_language = original_holder.selected_language
-	to_chat(stored, "DEBUG: Backed up [backup_understood_languages?.len || "NULL"] understood, [backup_spoken_languages?.len || "NULL"] spoken languages")
-
 
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
 
-		// Restore languages AFTER mind transfer (update_atom_languages() will have cleared LANGUAGE_ATOM sources)
+		// Restore languages AFTER mind transfer (update_atom_languages() will have cleared all languages from the mind since it draws from the atom's language holder)
 		var/datum/language_holder/mind_holder = shape.mind?.get_language_holder()
 		if(mind_holder && backup_understood_languages && backup_spoken_languages)
-			// Restore all understood languages
 			for(var/language in backup_understood_languages)
-				var/list/sources = backup_understood_languages[language]
-				for(var/source_type in sources)
-					mind_holder.grant_language(language, TRUE, FALSE, source_type)
+				mind_holder.grant_language(language, TRUE, FALSE)
 
-			// Restore all spoken languages
 			for(var/language in backup_spoken_languages)
-				var/list/sources = backup_spoken_languages[language]
-				for(var/source_type in sources)
-					mind_holder.grant_language(language, FALSE, TRUE, source_type)
+				mind_holder.grant_language(language, FALSE, TRUE)
 
-			// Restore selected language if possible
 			if(backup_selected_language && mind_holder.can_speak_language(backup_selected_language))
 				mind_holder.selected_language = backup_selected_language
 
@@ -232,37 +217,19 @@
 	if(shape.mind)
 		shape.mind.transfer_to(stored)
 
-		// Restore languages to the carbon AFTER mind transfer back
-		var/datum/language_holder/restored_holder = stored.get_language_holder()
+		// transfer_to calls update_atom_languages(), and the atom language holder doesn't store our languages from quirks, so restore from backup list created in Initialize()
+		var/datum/language_holder/restored_holder = stored.get_language_holder() //defaults to the mind language holder, if it exists
 		if(restored_holder && backup_understood_languages && backup_spoken_languages)
-			to_chat(stored, "DEBUG: About to restore languages. Clearing existing languages first.")
-
-			// Clear all existing languages
 			restored_holder.remove_all_languages()
 
-			// Restore all understood languages with their original sources
 			for(var/language_type in backup_understood_languages)
-				var/list/sources = backup_understood_languages[language_type]
-				to_chat(stored, "DEBUG: Restoring understood [language_type] with [sources.len] sources")
-				for(var/source_type in sources)
-					restored_holder.grant_language(language_type, TRUE, FALSE, source_type)
+				restored_holder.grant_language(language_type, TRUE, FALSE)
 
-			// Restore all spoken languages with their original sources
 			for(var/language_type in backup_spoken_languages)
-				var/list/sources = backup_spoken_languages[language_type]
-				to_chat(stored, "DEBUG: Restoring spoken [language_type] with [sources.len] sources")
-				for(var/source_type in sources)
-					restored_holder.grant_language(language_type, FALSE, TRUE, source_type)
+				restored_holder.grant_language(language_type, FALSE, TRUE)
 
-			// Restore selected language
 			if(backup_selected_language)
-				if(restored_holder.can_speak_language(backup_selected_language))
-					restored_holder.selected_language = backup_selected_language
-					to_chat(stored, "DEBUG: Restored selected language: [backup_selected_language]")
-				else
-					to_chat(stored, "DEBUG: Could not restore selected language [backup_selected_language] - not speakable")
-
-			to_chat(stored, "DEBUG: Language restoration complete. Final counts: [restored_holder.understood_languages.len] understood, [restored_holder.spoken_languages.len] spoken")
+				restored_holder.selected_language = backup_selected_language
 
 	if(death)
 		stored.death()

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -144,7 +144,7 @@
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
 
-		// Restore languages AFTER mind transfer (update_atom_languages() will have cleared all languages from the mind since it draws from the atom's language holder)
+		// Bring stored languages after transfer_to (transfer_to calls update_atom_languages() which will have cleared all languages from the mind since it draws from the atom's language holder)
 		var/datum/language_holder/mind_holder = shape.mind?.get_language_holder()
 		if(mind_holder && backup_understood_languages && backup_spoken_languages)
 			for(var/language in backup_understood_languages)
@@ -239,8 +239,18 @@
 		var/dam_percentage = ((shape.health / shape.maxHealth)) // getting percentage of your current hp compared to max HP in shape form
 		var/percent_carbon = (stored.maxHealth * dam_percentage) //this will get the HP remaining left you have in carbon form at base
 		var/gross_damage = (stored.maxHealth - percent_carbon) //This will give you the relative percentage damage you'd take once transforming back
+/* EXAMPLE CALCULATION
+dama_percentage = ( 1 (current HP) / 100 (max hp) ) = 0.002
+percent_carbon = 100 * 0.002 = 0.2
+gross_damage = 100 - 0.2 = 99.75
+Result: you take at least 90 damage when you trasnform back
+*/
 		stored.apply_damage(gross_damage, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND)
+
 //END OF TFN MODIFIED STUFF
+
+//	if(source.convert_damage)
+//		stored.blood_volume = shape.blood_volume;
 
 	// This guard is important because restore() can also be called on COMSIG_QDELETING for shape, as well as on death.
 	// This can happen in, for example, [/proc/wabbajack] where the mob hit is qdel'd.

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -114,6 +114,10 @@
 	var/mob/living/shape
 	var/restoring = FALSE
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/source
+	// Store language data separately from the language holder to preserve across mind transfers
+	var/list/backup_understood_languages
+	var/list/backup_spoken_languages
+	var/backup_selected_language
 
 /obj/shapeshift_holder/Initialize(mapload,obj/effect/proc_holder/spell/targeted/shapeshift/_source, mob/living/caster)
 	. = ..()
@@ -122,8 +126,51 @@
 	if(!istype(shape))
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster
+
+	// Backup language data BEFORE moving the caster anywhere
+	var/datum/language_holder/original_holder = stored.get_language_holder()
+	if(original_holder)
+		backup_understood_languages = list()
+		backup_spoken_languages = list()
+
+		// Deep copy understood languages with their sources
+		for(var/language in original_holder.understood_languages)
+			var/list/sources = original_holder.understood_languages[language]
+			backup_understood_languages[language] = sources.Copy()
+
+		// Deep copy spoken languages with their sources
+		for(var/language in original_holder.spoken_languages)
+			var/list/sources = original_holder.spoken_languages[language]
+			backup_spoken_languages[language] = sources.Copy()
+
+		backup_selected_language = original_holder.selected_language
+
+		backup_selected_language = original_holder.selected_language
+	to_chat(stored, "DEBUG: Backed up [backup_understood_languages?.len || "NULL"] understood, [backup_spoken_languages?.len || "NULL"] spoken languages")
+
+
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
+
+		// Restore languages AFTER mind transfer (update_atom_languages() will have cleared LANGUAGE_ATOM sources)
+		var/datum/language_holder/mind_holder = shape.mind?.get_language_holder()
+		if(mind_holder && backup_understood_languages && backup_spoken_languages)
+			// Restore all understood languages
+			for(var/language in backup_understood_languages)
+				var/list/sources = backup_understood_languages[language]
+				for(var/source_type in sources)
+					mind_holder.grant_language(language, TRUE, FALSE, source_type)
+
+			// Restore all spoken languages
+			for(var/language in backup_spoken_languages)
+				var/list/sources = backup_spoken_languages[language]
+				for(var/source_type in sources)
+					mind_holder.grant_language(language, FALSE, TRUE, source_type)
+
+			// Restore selected language if possible
+			if(backup_selected_language && mind_holder.can_speak_language(backup_selected_language))
+				mind_holder.selected_language = backup_selected_language
+
 	stored.forceMove(src)
 	stored.notransform = TRUE
 	if(source.convert_damage)
@@ -184,6 +231,39 @@
 	stored.notransform = FALSE
 	if(shape.mind)
 		shape.mind.transfer_to(stored)
+
+		// Restore languages to the carbon AFTER mind transfer back
+		var/datum/language_holder/restored_holder = stored.get_language_holder()
+		if(restored_holder && backup_understood_languages && backup_spoken_languages)
+			to_chat(stored, "DEBUG: About to restore languages. Clearing existing languages first.")
+
+			// Clear all existing languages
+			restored_holder.remove_all_languages()
+
+			// Restore all understood languages with their original sources
+			for(var/language_type in backup_understood_languages)
+				var/list/sources = backup_understood_languages[language_type]
+				to_chat(stored, "DEBUG: Restoring understood [language_type] with [sources.len] sources")
+				for(var/source_type in sources)
+					restored_holder.grant_language(language_type, TRUE, FALSE, source_type)
+
+			// Restore all spoken languages with their original sources
+			for(var/language_type in backup_spoken_languages)
+				var/list/sources = backup_spoken_languages[language_type]
+				to_chat(stored, "DEBUG: Restoring spoken [language_type] with [sources.len] sources")
+				for(var/source_type in sources)
+					restored_holder.grant_language(language_type, FALSE, TRUE, source_type)
+
+			// Restore selected language
+			if(backup_selected_language)
+				if(restored_holder.can_speak_language(backup_selected_language))
+					restored_holder.selected_language = backup_selected_language
+					to_chat(stored, "DEBUG: Restored selected language: [backup_selected_language]")
+				else
+					to_chat(stored, "DEBUG: Could not restore selected language [backup_selected_language] - not speakable")
+
+			to_chat(stored, "DEBUG: Language restoration complete. Final counts: [restored_holder.understood_languages.len] understood, [restored_holder.spoken_languages.len] spoken")
+
 	if(death)
 		stored.death()
 	else if(source.convert_damage)
@@ -192,19 +272,8 @@
 		var/dam_percentage = ((shape.health / shape.maxHealth)) // getting percentage of your current hp compared to max HP in shape form
 		var/percent_carbon = (stored.maxHealth * dam_percentage) //this will get the HP remaining left you have in carbon form at base
 		var/gross_damage = (stored.maxHealth - percent_carbon) //This will give you the relative percentage damage you'd take once transforming back
-/* EXAMPLE CALCULATION
-dama_percentage = ( 1 (current HP) / 100 (max hp) ) = 0.002
-percent_carbon = 100 * 0.002 = 0.2
-gross_damage = 100 - 0.2 = 99.75
-
-Result: you take at least 90 damage when you trasnform back
-*/
 		stored.apply_damage(gross_damage, source.convert_damage_type, forced = TRUE, wound_bonus=CANT_WOUND)
-
 //END OF TFN MODIFIED STUFF
-
-//	if(source.convert_damage)
-//		stored.blood_volume = shape.blood_volume;
 
 	// This guard is important because restore() can also be called on COMSIG_QDELETING for shape, as well as on death.
 	// This can happen in, for example, [/proc/wabbajack] where the mob hit is qdel'd.

--- a/code/modules/wod13/datums/powers/discipline/animalism.dm
+++ b/code/modules/wod13/datums/powers/discipline/animalism.dm
@@ -156,7 +156,7 @@
 	owner.beastmaster |= bat
 	bat.beastmaster_owner = owner
 
-//RAT SHAPESHIFT
+//'FLYING' RAT (BAT) SHAPESHIFT
 /obj/effect/proc_holder/spell/targeted/shapeshift/animalism
 	name = "Animalism Form"
 	desc = "Take on the shape a bat."
@@ -166,10 +166,11 @@
 	die_with_shapeshifted_form = FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/beastmaster/rat/flying
 
+//SKITTER - Bat Shapeshift
 /datum/discipline_power/animalism/rat_shapeshift
 	name = "Skitter"
 	desc = "Become one of the bats that fly above the city."
-
+	level = 5
 	check_flags = DISC_CHECK_IMMOBILE | DISC_CHECK_CAPABLE | DISC_CHECK_LYING
 
 	violates_masquerade = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR fixes players losing their language quirks when utilizing abilities that have simplemob transformations (Protean, Animalism, Vicissitude, others). This issue appears to be happening because the transfer_to proc on /datum/mind calls update_atom_languages() (inheriting from the atom level language holder) whereas all of our language data is stored on the mind-level language holder (with atom-level source flags).

Basically it goes (mind has 6 languages, atom has 1, transfer_to not called) -> (mind has 6 languages, atom has 1, transfer_to is called, mind now has 1 languages) -> (mind has 1 languages, atom has 1, transfer_to is called, mind now has 1 languages)

This issue is solved by creating backup lists before, during, and after the simplemob transformation which stores(before), and restores (during and after) the original mind language holder's spoken_languages and understood_languages lists. 

A note for Xeon -- I checked out how /tg/ does this and it appears that they made an entirely new proc /datum/language_holder/proc/transfer_mind_languages, and they call this on /datum/mind/proc/transfer_to, but a key reason why this isn't satisfactory for our codebase is because it appears to only consider languages with the 'mind' source flag. Nearly all of ours use the 'atom' source flag. Rebase will save us

(also for xeon, the /tg/ files which have the procs are _language_holder.dm and _mind.dm incase you think this can be done better since this is probably not optimal)

## Why It's Good For The Game

there are several ahelps about this every round

## Testing Photographs and Procedure

<img width="160" height="119" alt="dreamseeker_CswtzpiqFW" src="https://github.com/user-attachments/assets/4ab25c47-f61a-41c3-8c2f-117b9da820c7" />

<img width="1008" height="816" alt="dreamseeker_fjKEiHdZRC" src="https://github.com/user-attachments/assets/a6875db0-11ef-4cf4-a77e-ea906ed39c8c" />

<img width="1172" height="781" alt="dreamseeker_xMPITeVO6y" src="https://github.com/user-attachments/assets/83047130-f771-480d-8fa3-ea8849eac95e" />


## Changelog


:cl:

fix: Simplemob transformations no longer delete your character's languages

/:cl:


