### PR TITLE
Diablerie flaw elaboration

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -663,7 +663,7 @@ Dancer
 
 /datum/quirk/diablerist
 	name = "Diablerist"
-	desc = "For one reason or another, you have very recently committed Diablerie in your past, a great crime within Kindred society. Your sin of the Amaranth is apparent to many Kindred.  <b>This is not a license to Diablerize without proper reason! If you are found out, you can (and most likely will be) round removed. You have been warned.</b>"
+	desc = "For one reason or another, you have very recently committed Diablerie in your past, a great crime within Kindred society. Your sin of the Amaranth is apparent to many Kindred, and will only fade as months pass.  <b>This is not a license to Diablerize without proper reason! If you are found out, you can (and most likely will be) round removed. You have been warned.</b>"
 	value = 0
 	allowed_species = list("Vampire")
 

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -663,7 +663,7 @@ Dancer
 
 /datum/quirk/diablerist
 	name = "Diablerist"
-	desc = "For one reason or another, you have committed Diablerie in your past, a great crime within Kindred society. <b>This is not a license to Diablerize without proper reason! If you are found out, you can (and most likely will be) round removed. You have been warned.</b>"
+	desc = "For one reason or another, you have very recently committed Diablerie in your past, a great crime within Kindred society. Your sin of the Amaranth is apparent to many Kindred.  <b>This is not a license to Diablerize without proper reason! If you are found out, you can (and most likely will be) round removed. You have been warned.</b>"
 	value = 0
 	allowed_species = list("Vampire")
 

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -663,7 +663,7 @@ Dancer
 
 /datum/quirk/diablerist
 	name = "Diablerist"
-	desc = "For one reason or another, you have very recently committed Diablerie in your past, a great crime within Kindred society. Your sin of the Amaranth is apparent to many Kindred, and will only fade as months pass.  <b>This is not a license to Diablerize without proper reason! If you are found out, you can (and most likely will be) round removed. You have been warned.</b>"
+	desc = "For one reason or another, you have very recently committed Diablerie in your past, a great crime within Kindred society. Your sin of the Amaranth is apparent to many Kindred, and will only fade in a year or two.  <b>This is not a license to Diablerize without proper reason! If you are found out, you can (and most likely will be) round removed. You have been warned.</b>"
 	value = 0
 	allowed_species = list("Vampire")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Specifies that the aura of Diablerie only implies a recent Diablerie.

## Why It's Good For The Game

Players may take the quirk without understanding the lore implications, only the repercussions. Diablerie aura doesn't last more than a couple of years in most cases. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="865" height="87" alt="V34yCWyXIK" src="https://github.com/user-attachments/assets/d2c977db-e766-4d6a-aa23-9a1da082f6f3" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Adds to the Diablerist quirk text.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
