### PR TITLE
Leaden Moment Fix

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/temporis.dm
+++ b/code/modules/wod13/datums/powers/discipline/temporis.dm
@@ -22,7 +22,7 @@
 
 	return POWER_CANCEL_ACTIVATION
 
-//HOURGLASS OF THE MIND
+// **************************************************************** HOURGLASS OF THE MIND *************************************************************
 /datum/discipline_power/temporis/hourglass_of_the_mind
 	name = "Hourglass of the Mind"
 	desc = "Gain a perfect sense of time. Know exactly when you are, and share this knowledge with others."
@@ -59,7 +59,7 @@
 		to_chat(owner, span_notice("There are no temporal distortions nearby."))
 	return TRUE
 
-//RECURRING CONTEMPLATION
+// **************************************************************** RECURRING CONTEMPLATION *************************************************************
 /datum/discipline_power/temporis/recurring_contemplation
 	name = "Recurring Contemplation"
 	desc = "Trap your target into repeating the same set of actions."
@@ -85,10 +85,9 @@
 		to_chat(owner, span_userdanger("<b>You fail to affect your target!</b>"))
 		return
 
-//LEADEN MOMENT
+// **************************************************************** LEADEN MOMENT *************************************************************
 /datum/movespeed_modifier/temporis3
-	//Modifier applied by Leaden Moment, default value of 1
-	multiplicative_slowdown = 1
+	multiplicative_slowdown = 1 // Modifier applied by Leaden Moment, default value of 1
 
 /datum/discipline_power/temporis/leaden_moment
 	name = "Leaden Moment"
@@ -105,9 +104,10 @@
 	cooldown_length = 1 TURNS
 	duration_override = TRUE
 
-	//Variables for speed value modifier & dynamic duration
+	// Variables for speed value modifier & dynamic duration
 	var/datum/movespeed_modifier/temporis3/active_mod
 	var/discduration
+	var/mob/living/affected_mob // Track which mob is affected
 
 /datum/discipline_power/temporis/leaden_moment/activate(mob/living/target)
 	. = ..()
@@ -120,43 +120,37 @@
 	var/trueroll = abs(success)
 	if(!success)
 		return FALSE
-	//Discipline duration, 1 turn per 2 successes, rounded up
-	var/discduration = CEILING(trueroll/2,1) TURNS
-	//Half movement & action speed at 1 success, scaling per 2 successes after (1/3 at 3, 1/4 at 5, etc)
-	var/slowdown = 1 + CEILING(trueroll/2,1)
-	var/mob/living/affected_mob
+	discduration = CEILING(trueroll/2,1) TURNS // Discipline duration, 1 turn per 2 successes, rounded up
+	var/slowdown = 1 + CEILING(trueroll/2,1) // Half movement & action speed at 1 success, scaling per 2 successes after (1/3 at 3, 1/4 at 5, etc)
 
 	//Determine targets, start timers
 	if(success > 0)
-		addtimer(CALLBACK(src, PROC_REF(deactivate),target), discduration)
-		to_chat(target, span_userdanger("<b>Time seems to slow to a crawl around you...</b>"))
 		affected_mob = target
+		to_chat(target, span_userdanger("<b>Time seems to slow to a crawl around you...</b>"))
 	else if(success < 0)
-		//Botch causes the owner to be slowed instead
-		addtimer(CALLBACK(src, PROC_REF(deactivate)), discduration)
+		affected_mob = owner // Botch causes the owner to be affected instead
 		to_chat(owner, span_userdanger("<b>Your temporal manipulation backfires!</b>"))
-		affected_mob = owner
 
-	//Apply modifiers to target
+	// Apply modifiers to affected mob
 	active_mod = new
 	active_mod.multiplicative_slowdown = slowdown
 	affected_mob.add_movespeed_modifier(active_mod, TRUE)
 	affected_mob.next_move_modifier *= slowdown
+
+	addtimer(CALLBACK(src, PROC_REF(deactivate)), discduration)
 	return TRUE
 
-/datum/discipline_power/temporis/leaden_moment/deactivate(mob/living/target)
+/datum/discipline_power/temporis/leaden_moment/deactivate()
 	. = ..()
-	if(active_mod)
-		if(target)
-			target.remove_movespeed_modifier(active_mod, TRUE)
-			target.next_move_modifier /= active_mod.multiplicative_slowdown
-		if(owner)
-			owner.remove_movespeed_modifier(active_mod, TRUE)
-			owner.next_move_modifier /= active_mod.multiplicative_slowdown
+	//Remove modifiers from affected mob
+	if(active_mod && affected_mob)
+		affected_mob.remove_movespeed_modifier(active_mod, TRUE)
+		affected_mob.next_move_modifier /= active_mod.multiplicative_slowdown
 		qdel(active_mod)
 		active_mod = null
+		affected_mob = null
 
-//COWALKER
+// **************************************************************** COWALKER *************************************************************
 /datum/discipline_power/temporis/cowalker
 	name = "Cowalker"
 	desc = "Be in multiple places at once, creating several false images."
@@ -209,10 +203,9 @@
 	spawn(0.5 SECONDS)
 		qdel(src)
 
-//CLOTHO'S GIFT
+// **************************************************************** CLOTHO'S GIFT *************************************************************
 /datum/movespeed_modifier/temporis5
-	//Modifier applied by Clotho's Gift
-	var/speed_modifier
+	var/speed_modifier // Modifier applied by Clotho's Gift
 
 /datum/discipline_power/temporis/clothos_gift
 	name = "Clotho's Gift"
@@ -227,14 +220,14 @@
 	duration_length = 3 TURNS
 	cooldown_length = 1 TURNS
 
-	//Speed modifier & active modifier
+	// Speed modifier & active modifier
 	var/speed_modifier
 	var/datum/movespeed_modifier/temporis5/active_modifier
 
 /datum/discipline_power/temporis/clothos_gift/activate()
 	. = ..()
 
-	//Roll for degree of success, mentality + social in place of intelligence + occult
+	// Roll for degree of success, mentality + social in place of intelligence + occult
 	var/dice = owner.get_total_mentality() + owner.get_total_social()
 	var/success = SSroll.storyteller_roll(dice, difficulty = 7, mobs_to_show_output = owner, numerical = TRUE)
 	if(success > 0)
@@ -242,7 +235,7 @@
 	else
 		cancelable = FALSE
 
-	//Applying the modifiers
+	// Applying the modifiers
 	active_modifier = new
 	active_modifier.speed_modifier = success
 	active_modifier.multiplicative_slowdown = -success
@@ -255,7 +248,7 @@
 
 /datum/discipline_power/temporis/clothos_gift/deactivate()
 	. = ..()
-	//Removing the modifiers
+	// Removing the modifiers
 	if(active_modifier)
 		if(active_modifier != 0)
 			owner.remove_movespeed_modifier(active_modifier)
@@ -276,7 +269,7 @@
 		animate(temporis_visual, pixel_x = rand(-32,32), pixel_y = rand(-32,32), alpha = 155, time = 0.5 SECONDS)
 		SEND_SIGNAL(owner, COMSIG_MASQUERADE_VIOLATION)
 
-//KISS OF LACHESIS
+// **************************************************************** KISS OF LACHESIS *************************************************************
 /datum/discipline_power/temporis/kiss_of_lachesis
 	name = "Kiss of Lachesis"
 	desc = "Change a target's biological age."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes Leaden Moment, because I forgot to add a check for who it was affecting in deactivation, resulting in permanent stacking action speed modifiers.

## Why It's Good For The Game

Infinitely stacking action speed modifiers due to a bug is bad, apparently. Who knew...

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/2664b2e1-6a54-452a-a12a-224fea4dd408

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
bugfix: Fixed an issue with Temporis 3, Leaden Moment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
