### PR TITLE
Fixes Pancake Stacking

### DIFF
--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -778,7 +778,6 @@
 		for(var/atom/movable/part in parts_list)
 			qdel(part)
 	update_icon()
-	return
 
 /obj/item/food/pancakes/update_icon()
 	. = ..()

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -773,6 +773,13 @@
 	. = ..()
 	update_icon()
 
+/obj/item/food/pancakes/CheckParts(list/parts_list, datum/crafting_recipe/R)
+	if(parts_list && parts_list.len > 0)
+		for(var/atom/movable/part in parts_list)
+			qdel(part)
+	update_icon()
+	return
+
 /obj/item/food/pancakes/update_icon()
 	. = ..()
 	if(contents.len)


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug where pancakes crafted from the crafting menu were immediately crafted as 'stack of pancakes' despite being just one pancake. When stacking them, it would cause an 'error' sprite. 

This was happening because the base CheckParts() used in crafting forcemoved the reagents into the pancake, incrementing it's contents by one. Ergo if you crafted one pancake with one pastrybase, the pastrybase wouldnt actually be deleted, it would just get forcemoved into the pancake, causing the pancake to become a stack of pancakes, or rather, a stack of one pancake and one pastrybase, which, there isn't even supposed to be pastrybases in pancakestacks anyways, and thus the error sprite.

I fixed this by creating a proc override for CheckParts() specifically for pancakes that qdeletes the pastrybase instead of forcemoving it onto the pancake.

Full disclosure I fullmerged the cooking pr while there were bugs reported so this was my fault

## Why It's Good For The Game

bugfix 

## Testing Photographs and Procedure
before
<img width="1308" height="995" alt="dreamseeker_s0kEaC8sF3" src="https://github.com/user-attachments/assets/f042dc39-2212-45e4-abd3-517254032c40" />

during
<img width="1240" height="978" alt="dreamseeker_fFHRz5mIW8" src="https://github.com/user-attachments/assets/f09ae24a-0918-40ae-87d9-c895c234dcc5" />

after
<img width="1158" height="982" alt="dreamseeker_eVwz6xXj1b" src="https://github.com/user-attachments/assets/4999a6b4-c0ad-4dea-a517-143fc56b2a26" />



## Changelog

:cl:

bugfix: stacking pancakes no longer causes an error sprite
/:cl:

