### PR TITLE
Fixes Languages Bug

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -243,7 +243,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	return TRUE
 
-/mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), thrown = FALSE)
+/mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), thrown = FALSE) // TFN EDIT - added 'thrown' var to handle melpominee_say proc on the discipline Melpominee.
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 	if(!client)
 		return
@@ -291,9 +291,13 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 					EX.last_message = message
 					EX.total_erp += length_char(message)
 
+	//TFN EDIT START - Fixes Languages Bug - Line 297 handles language comprehension but we dont want it to run if thrown = TRUE (melpominee_say from melpominee.dm)
+
 	// Recompose message for AI hrefs, language incomprehension.
 	if(!thrown)
 		message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods) //TFN EDIT, REMOVAL
+
+	//TFN EDIT END - Fixes Languages Bug
 
 	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlighting = speaker == src)
 	return message

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -243,7 +243,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	return TRUE
 
-/mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
+/mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), thrown = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 	if(!client)
 		return
@@ -292,7 +292,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 					EX.total_erp += length_char(message)
 
 	// Recompose message for AI hrefs, language incomprehension.
-	//message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods) //TFN EDIT, REMOVAL
+	if(!thrown)
+		message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods) //TFN EDIT, REMOVAL
 
 	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlighting = speaker == src)
 	return message

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	// Recompose message for AI hrefs, language incomprehension.
 	if(!thrown)
-		message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods) //TFN EDIT, REMOVAL
+		message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
 	//TFN EDIT END - Fixes Languages Bug
 

--- a/code/modules/wod13/datums/powers/discipline/melpominee.dm
+++ b/code/modules/wod13/datums/powers/discipline/melpominee.dm
@@ -71,7 +71,7 @@
 		var/atom/movable/AM = _AM
 		if(get_dist(AM, src) > 7)
 			rendered = "<span class='scream_away'>[rendered]</span>" //! Take an attention, this will NOT overlap client font-size, fix it if you can
-		AM.Hear(rendered, src, language, message, , spans, message_mods)
+		AM.Hear(rendered, src, language, message, , spans, message_mods, TRUE)
 
 /datum/discipline_power/melpominee/proc/speaker_mouth_check(mob/living/target)
 	//viewers are able to detect if a person's words aren't their own


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug associated with languages. In the 'Hear' method a line was commented out that handled language comprehension which was necessary for Melpominee to have the user be able to 'throw' their voice, rather than forcing someone to speak. 

This PR fixes that bug by adding a new arg to 'Hear' ('thrown') which is always FALSE unless otherwise flipped TRUE, and it is only flipped to TRUE when called by melpominee_say. 

In Hear, if thrown is not true, the previously commented out line runs, handling language comprehension. If thrown is true, the line does not run, which only happens for Melpominee.

## Why It's Good For The Game

bugfix

## Testing Photographs and Procedure

From Gary Donkin the melpominee user's perspective


<img width="1286" height="620" alt="dreamseeker_gOwK8ibCdg" src="https://github.com/user-attachments/assets/6321d9a3-5e40-4460-afd9-8184fd04928d" />

From Ty David the Melpominee victim's perspective (you can see she cannot understand Hebrew)

<img width="1097" height="595" alt="dreamseeker_NQLRWz2MJo" src="https://github.com/user-attachments/assets/fdc114a8-004a-4054-b863-3096686f18b2" />



## Changelog

:cl:

fix: fixes a bug related to everyone being able to understand every language

/:cl:


