### PR TITLE
Janicart Fix. Mop now doesn't get eaten.

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -24,6 +24,11 @@
 	AddComponent(/datum/component/cleaner, mopspeed, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean)), on_cleaned_callback=CALLBACK(src, PROC_REF(apply_reagents)))
 	create_reagents(mopcap)
 
+/obj/item/mop/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J) //sadly the copypasta is the simple way
+	J.put_in_cart(src, user)
+	J.mymop=src
+	J.update_appearance()
+
 /obj/item/mop/proc/clean(turf/A, mob/living/cleaner)
 	var/really = FALSE
 	for(var/obj/effect/decal/cleanable/blood/B in A)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -47,7 +47,7 @@
 			if (wet_mop(m, user))
 				return
 		if(!mymop)
-			put_in_cart(m, user)
+			m.janicart_insert(user, src)
 		else
 			to_chat(user, fail_msg)
 	else if(istype(I, /obj/item/pushbroom))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now add and remove mops to the janicart without the cart sending it to the void.

## Why It's Good For The Game



## Testing Photographs and Procedure

I made the code the same as the other items that you can add to the cart.

I tested this change in a self-hosted world and can confirm it functions.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
bugfix: Mops aren't eaten by the janitor cart now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
