### PR TITLE
Corax Crinos can rip doors off to match Crinos behaviour as reported bug.

### DIFF
--- a/modular_tfn/modules/werewolf/werewolf_mob/werewolf_interactions.dm
+++ b/modular_tfn/modules/werewolf/werewolf_mob/werewolf_interactions.dm
@@ -34,10 +34,12 @@
 			playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
 
 /obj/structure/vampdoor/attack_werewolf(mob/living/carbon/werewolf/user, list/modifiers)
-	if (!user.combat_mode || !closed || !iscrinos(user))
+	if (user.combat_mode && closed && (iscrinos(user) || iscoraxcrinos(user)))
+		break_door(user)
+	else
 		return ..()
 
-	break_door(user)
+
 
 /mob/living/attack_werewolf(mob/living/carbon/werewolf/user, list/modifiers)
 	attack_paw(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Requested bugfix by Cedric Gilas.

I rearranged the check only because notting iscrinos and notting iscoraxcrinos would result in nothing being valid and trying to work the logic out inverted gave me a headache.


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

I was requested to fix this as a bug. If the behaviour is intended, apologies.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->

Tested with:

Normal person, combat and not combat with door open and closed.
Garou, as above plus non-crinos and crinos.
Corax, as above.

Correct behviour observed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
bugfix: Corax Crinos mirror Crinos in that both can now remove doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
