### PR TITLE
adding salubri keys to the salubri job

### DIFF
--- a/code/modules/vtmb/jobs/bloodlines/salubri.dm
+++ b/code/modules/vtmb/jobs/bloodlines/salubri.dm
@@ -34,6 +34,7 @@
 		/obj/item/passport=1,
 		/obj/item/flashlight=1,
 		/obj/item/vamp/creditcard=1,
+		/obj/item/vamp/keys/salubri,
 	)
 
 /datum/outfit/job/salubri/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION

## About The Pull Request

gives the salubri job the keys

## Why It's Good For The Game

it seems like an oversight

## Testing Photographs and Procedure
<img width="916" height="734" alt="image" src="https://github.com/user-attachments/assets/a65f31b4-85c3-4ef0-87a1-3b3c4488faaa" />
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
qol: gives Veterinarian keys to their building
/:cl:
