### PR TITLE
Added the missing teleport destination for the Anarchy Rose.

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -74271,6 +74271,22 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f3)
+"qZP" = (
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/machinery/light/small/red{
+	pixel_y = 32
+	},
+/obj/transfer_point_vamp{
+	alpha = 0;
+	density = 0;
+	id = 671
+	},
+/turf/open/floor/plating/toilet{
+	color = "#636363"
+	},
+/area/vtm/anarch)
 "qZZ" = (
 /obj/structure/railing{
 	dir = 10
@@ -150853,7 +150869,7 @@ iQQ
 dSH
 dSH
 uHB
-iiO
+qZP
 ggd
 naa
 naa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes a missing teleport destination for the Anarchy Rose.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Replacing what got accidentally cut in a remap.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Dazed and confused, Needs-No-Picks escapes from the laboratory into the Umbra, and in a blind panic stumbles to the bar portal:

<img width="751" height="561" alt="Screenshot 2025-10-07 003014" src="https://github.com/user-attachments/assets/8a370455-2958-4813-be65-f9cb046786a1" />

Heading through, she re-emerges into relative safety, a toilet cubicle, and stumbles for the door out- Thank Gaia, the bar is closed!

<img width="747" height="664" alt="Screenshot 2025-10-07 003026" src="https://github.com/user-attachments/assets/8d390b7e-0ea0-4263-bdd6-ffd274408607" />

Now to escape, find help, and try to recover!

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


:cl:
bugfix: Added missing teleport destination to the Anarchy Rose from the Umbra.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
