### PR TITLE
Gives Lasombra Keys

### DIFF
--- a/code/modules/vtmb/vampire_clan/lasombra.dm
+++ b/code/modules/vtmb/vampire_clan/lasombra.dm
@@ -13,6 +13,7 @@
 	)
 	male_clothes = /obj/item/clothing/under/vampire/emo
 	female_clothes = /obj/item/clothing/under/vampire/business
+	clan_keys = /obj/item/vamp/keys/lasombra
 	is_enlightened = TRUE
 	whitelisted = FALSE
 


### PR DESCRIPTION

## About The Pull Request
Gives Lasombra keys to their own haven.

## Why It's Good For The Game
They should probably not be locked out while their Primogen ominously stares at them from a window.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<img width="167" height="105" alt="image" src="https://github.com/user-attachments/assets/8ec2c9e0-7367-46e5-b6d0-80b3d072a44e" />

<img width="1072" height="662" alt="image" src="https://github.com/user-attachments/assets/a350bacf-4832-4a01-8b68-bed0c6a8a2a4" />

<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: Lets the Lasombra enter their own haven, again.
/:cl:
